### PR TITLE
Add a way to find the projects that simply never updated

### DIFF
--- a/anitya/lib/model.py
+++ b/anitya/lib/model.py
@@ -461,6 +461,12 @@ class Project(BASE):
             query = query.filter(
                 Project.logs == None,
             )
+        elif status == 'never_updated':
+            query = query.filter(
+                Project.logs != None,
+                Project.logs != 'Version retrieved correctly',
+                Project.latest_version == None,
+            )
 
         if name:
             if '*' in name:

--- a/anitya/templates/master.html
+++ b/anitya/templates/master.html
@@ -83,6 +83,11 @@
                       Failed to update
                     </a>
                   </li>
+                  <li>
+                    <a href="{{url_for('projects_updated', status='never_updated')}}">
+                      Never updated
+                    </a>
+                  </li>
                 </ul>
             </li>
 

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -95,7 +95,7 @@ def projects_updated(status='updated'):
     except ValueError:
         page = 1
 
-    statuses = ['new', 'updated', 'failed']
+    statuses = ['new', 'updated', 'failed', 'never_updated']
 
     if status not in statuses:
         flask.flash(


### PR DESCRIPTION
Sometimes projects fail to update, but they did update before, it's just
that at the last cron run the server was down or something like this.
But we also have projects that simply never have been able to update, not
even once. Maybe the info we have about these projects are simply wrong,
maybe the project doesn't exists anymore.

This commit allows to find this type of projects
