### PR TITLE
Allow an initial mapping when creating a project.

### DIFF
--- a/anitya/forms.py
+++ b/anitya/forms.py
@@ -17,6 +17,9 @@ class ProjectForm(wtf.Form):
     version_url = TextField('Version URL', [validators.optional()])
     regex = TextField('Regex', [validators.optional()])
 
+    distro = TextField('Distro (optional)', [validators.optional()])
+    package_name = TextField('Package (optional)', [validators.optional()])
+
     def __init__(self, *args, **kwargs):
         """ Calls the default constructor with the normal argument but
         uses the list of backends provided to fill the choices of the

--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -36,6 +36,17 @@
               <th>Examples:</th>
               <td id="example_txt"></td>
             </tr>
+
+            {% if context == 'Add' %}
+            <tr>
+              {{ render_field_in_row(form.distro) }}
+              <td></td>
+            </tr>
+            <tr>
+              {{ render_field_in_row(form.package_name) }}
+              <td></td>
+            </tr>
+            {% endif %}
           </table>
         </span>
       </div>

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -270,6 +270,9 @@ def new_project():
         form.homepage.data = flask.request.args.get('homepage', '')
         form.backend.data = flask.request.args.get('backend', '')
 
+        form.distro.data = flask.request.args.get('distro', '')
+        form.package_name.data = flask.request.args.get('package_name', '')
+
     if form.validate_on_submit():
         project = None
         try:
@@ -282,6 +285,19 @@ def new_project():
                 regex=form.regex.data,
                 user_mail=flask.g.auth.email,
             )
+            SESSION.commit()
+
+            # Optionally, the user can also map a distro when creating a proj.
+            if form.distro.data and form.package_name.data:
+                anitya.lib.map_project(
+                    SESSION,
+                    project=project,
+                    package_name=form.package_name.data,
+                    distribution=form.distro.data,
+                    user_mail=flask.g.auth.email,
+                )
+                SESSION.commit()
+
             flask.flash('Project created')
         except anitya.lib.exceptions.AnityaException as err:
             flask.flash(err)


### PR DESCRIPTION
When I'm adding an upstream project for the very first time, I want this quite
often -- I want to map packages in Fedora.  When I have 2 trillion packages to
map, it can be quite annoying without this: I have to open the form the create
the upstream project, submit it, click 'add a mapping', then fill out that
form, then submit it.. over and over for every project/package.

This commit alters that first 'new upstream project' form and gives it a
section to add an initial distro mapping in one go.

Fixes #52.
