### PR TITLE
update distro page text

### DIFF
--- a/anitya/templates/distros.html
+++ b/anitya/templates/distros.html
@@ -42,8 +42,7 @@
 
 <div class="row">
   <p>
-    Here is the list of all the distributions having at least one project
-    mapped monitored by anitya.
+    Here is the list of all the distributions that anitya knows about.
   </p>
   {% if is_admin %}
   <p>


### PR DESCRIPTION
it does list any distro that was listed at least once, it does not do
this based on current mapping. so there's chance the distro is listed
but at the moment there are zero project mappings
