### PR TITLE
Add api to query for a project by homepage.

### DIFF
--- a/tests/test_flask_api.py
+++ b/tests/test_flask_api.py
@@ -137,6 +137,35 @@ class AnityaWebAPItests(Modeltests):
 
         self.assertEqual(data, exp)
 
+        output = self.app.get('/api/projects/?homepage=http://www.geany.org/')
+        self.assertEqual(output.status_code, 200)
+        data = json.loads(output.data)
+
+        for key in range(len(data['projects'])):
+            del(data['projects'][key]['created_on'])
+            del(data['projects'][key]['updated_on'])
+
+        exp = {
+            "projects": [
+                {
+                    "id": 1,
+                    "backend": "custom",
+                    "homepage": "http://www.geany.org/",
+                    "name": "geany",
+                    "regex": "DEFAULT",
+                    "version": None,
+                    "version_url": "http://www.geany.org/Download/Releases",
+                    "versions": [],
+                },
+            ],
+            "total": 1
+        }
+
+        self.assertEqual(data, exp)
+
+        output = self.app.get('/api/projects/?pattern=foo&homepage=bar')
+        self.assertEqual(output.status_code, 400)
+
     def test_api_packages_wiki_list(self):
         """ Test the api_packages_wiki_list function of the API. """
         create_distro(self.session)


### PR DESCRIPTION
I'm thinking that we can use this when a new package gets added to Fedora.  We
can look up its upstream_url in pkgdb, and then query anitya to see if any
projects are registered with that homepage.  If there are not, then add one
with this new package if its backend is an easy one (pypi, rubygems, etc).