### PR TITLE
On postgresql '_' is a special character that we should escape

### DIFF
--- a/anitya/lib/model.py
+++ b/anitya/lib/model.py
@@ -521,6 +521,7 @@ class Project(BASE):
     def search(cls, session, pattern, distro=None, page=None, count=False):
         ''' Search the projects by their name or package name '''
 
+        pattern = pattern.replace('_', '\_')
         if '*' in pattern:
             pattern = pattern.replace('*', '%')
 


### PR DESCRIPTION
Escaping it brings back the default behavior allowing the search for
mod_* and have this return mod_perl, mod_wsgi & co

Fixes https://github.com/fedora-infra/anitya/issues/86