### PR TITLE
Allow projects to make insecure http calls

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,59 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = alembic
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# max length of characters to apply to the
+# "slug" field
+#truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+#sqlalchemy.url = driver://user:pass@localhost/dbname
+sqlalchemy.url = sqlite:////var/tmp/anitya-dev.sqlite
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,71 @@
+from __future__ import with_statement
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from logging.config import fileConfig
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = None
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    engine = engine_from_config(
+                config.get_section(config.config_ini_section),
+                prefix='sqlalchemy.',
+                poolclass=pool.NullPool)
+
+    connection = engine.connect()
+    context.configure(
+                connection=connection,
+                target_metadata=target_metadata
+                )
+
+    try:
+        with context.begin_transaction():
+            context.run_migrations()
+    finally:
+        connection.close()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()
+

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,22 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision}
+Create Date: ${create_date}
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/571bd07533a9_add_insecure_column_to_projects_table.py
+++ b/alembic/versions/571bd07533a9_add_insecure_column_to_projects_table.py
@@ -15,12 +15,18 @@ import sqlalchemy as sa
 
 
 def upgrade():
+    ''' Add the `insecure` column on the projects table. '''
     op.add_column(
         'projects',
         sa.Column(
-            'insecure', sa.Boolean(), nullable=False, server_default=False)
+            'insecure',
+            sa.Boolean,
+            default=False,
+            server_default="FALSE",
+            nullable=False)
     )
 
 
 def downgrade():
+    ''' Drop the `insecure` column of the projects table. '''
     op.drop_column('projects', 'insecure')

--- a/alembic/versions/571bd07533a9_add_insecure_column_to_projects_table.py
+++ b/alembic/versions/571bd07533a9_add_insecure_column_to_projects_table.py
@@ -1,0 +1,26 @@
+"""Add insecure column to projects table
+
+Revision ID: 571bd07533a9
+Revises: None
+Create Date: 2015-03-23 17:18:11.421783
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '571bd07533a9'
+down_revision = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column(
+        'projects',
+        sa.Column(
+            'insecure', sa.Boolean(), nullable=False, server_default=False)
+    )
+
+
+def downgrade():
+    op.drop_column('projects', 'insecure')

--- a/anitya/forms.py
+++ b/anitya/forms.py
@@ -3,7 +3,7 @@
 """ Forms used in anitya. """
 
 from flask.ext import wtf
-from wtforms import TextField, validators, SelectField
+from wtforms import TextField, validators, SelectField, BooleanField
 
 
 class ProjectForm(wtf.Form):
@@ -16,6 +16,8 @@ class ProjectForm(wtf.Form):
     )
     version_url = TextField('Version URL', [validators.optional()])
     regex = TextField('Regex', [validators.optional()])
+    insecure = BooleanField(
+        'Use insecure connection', [validators.optional()])
 
     distro = TextField('Distro (optional)', [validators.optional()])
     package_name = TextField('Package (optional)', [validators.optional()])

--- a/anitya/lib/__init__.py
+++ b/anitya/lib/__init__.py
@@ -114,7 +114,7 @@ def create_project(
 
 def edit_project(
         session, project, name, homepage, backend, version_url, regex,
-        user_mail):
+        insecure, user_mail):
     """ Edit a project in the database.
 
     """
@@ -141,6 +141,10 @@ def edit_project(
         project.regex = regex.strip() if regex else None
         if old != project.regex:
             changes['regex'] = {'old': old, 'new': project.regex}
+    if insecure != project.insecure:
+        old = project.insecure
+        project.insecure = insecure
+        changes['insecure'] = {'old': old, 'new': project.insecure}
 
     try:
         if changes:

--- a/anitya/lib/backends/__init__.py
+++ b/anitya/lib/backends/__init__.py
@@ -220,7 +220,7 @@ class BaseBackend(object):
         return anitya.order_versions(vlist)
 
     @classmethod
-    def call_url(self, url):
+    def call_url(self, url, insecure=False):
         ''' Dedicated method to query a URL.
 
         It is important to use this method as it allows to query them with
@@ -256,17 +256,17 @@ class BaseBackend(object):
                 'From': from_email,
             }
 
-            return requests.get(url, headers=headers)
+            return requests.get(url, headers=headers, verify=not insecure)
 
 
-def get_versions_by_regex(url, regex, project):
+def get_versions_by_regex(url, regex, project, insecure=False):
     ''' For the provided url, return all the version retrieved via the
     specified regular expression.
 
     '''
 
     try:
-        req = BaseBackend.call_url(url)
+        req = BaseBackend.call_url(url, insecure=insecure)
     except Exception, err:
         anitya.LOG.debug('%s ERROR: %s' % (project.name, err.message))
         raise AnityaPluginException(

--- a/anitya/lib/backends/custom.py
+++ b/anitya/lib/backends/custom.py
@@ -69,4 +69,5 @@ class CustomBackend(BaseBackend):
             regex = REGEX_ALIASES.get(project.regex, project.regex)
         regex = regex % {'name': project.name.replace('+', '\+')}
 
-        return get_versions_by_regex(url, regex, project)
+        return get_versions_by_regex(
+            url, regex, project, insecure=project.insecure)

--- a/anitya/lib/model.py
+++ b/anitya/lib/model.py
@@ -303,6 +303,7 @@ class Project(BASE):
     )
     version_url = sa.Column(sa.String(200), nullable=True)
     regex = sa.Column(sa.String(200), nullable=True)
+    insecure = sa.Column(sa.Boolean, nullable=False, default=False)
 
     latest_version = sa.Column(sa.String(50))
     logs = sa.Column(sa.Text)

--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -32,6 +32,9 @@
             <tr id="regex_row">
               {{ render_field_in_row(form.regex) }}
             </tr>
+            <tr id="insecure_row">
+              {{ render_field_in_row(form.insecure) }}
+            </tr>
             <tr id="examples_row">
               <th>Examples:</th>
               <td id="example_txt"></td>
@@ -97,6 +100,7 @@
   function show_hide(){
     $('#regex_row').hide();
     $('#version_url_row').hide();
+    $('#insecure_row').hide();
     $('#regex').attr('placeholder', '');
 
     $("label[for='version_url']").text('Version URL');
@@ -122,6 +126,7 @@
     if (str == 'custom'){
       $('#regex_row').show();
       $('#version_url_row').show();
+      $('#insecure_row').show();
       $('#regex').attr('placeholder', 'Leave empty for default regex');
     };
 

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -375,6 +375,7 @@ def edit_project(project_id):
                 backend=form.backend.data.strip(),
                 version_url=form.version_url.data.strip(),
                 regex=form.regex.data.strip(),
+                insecure=form.insecure.data,
                 user_mail=flask.g.auth.email,
             )
             flask.flash('Project edited')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,15 @@
-python-openid
-flask-openid
-flask
-sqlalchemy
-wtforms
-flask-wtf
-docutils
-markupsafe
+alembic
 bunch
+dateutils
+docutils
 fedmsg
+flask
+flask-openid
+flask-wtf
+markupsafe
+python-openid
+sqlalchemy
 # https://github.com/ironfroggy/straight.plugin/issues/17#issuecomment-41466275
 straight.plugin==1.4.0-post-1
-dateutils
+wtforms
+


### PR DESCRIPTION
The idea is to have a per project settings to allow insecure http call, ie calls made over https where the certificate does not match the hostname.

This should fix issues such as: https://github.com/fedora-infra/anitya/issues/70