### PR TITLE
Include in the fedmsg message if the new version found is odd or not

### DIFF
--- a/anitya/__init__.py
+++ b/anitya/__init__.py
@@ -79,9 +79,11 @@ def check_release(project, session):
             )
         )
 
+    odd_change = False
     if up_version and up_version != p_version:
         max_version = order_versions([up_version, p_version])[-1]
         if project.latest_version and max_version != up_version:
+            odd_change = True
             project.logs = 'Something strange occured, we found that this '\
                 'project has released a version "%s" while we had the latest '\
                 'version at "%s"' % (up_version, project.latest_version)
@@ -100,6 +102,7 @@ def check_release(project, session):
                 packages=[pkg.__json__() for pkg in project.packages],
                 versions=project.versions,
                 agent='anitya',
+                odd_change=odd_change,
             ),
         )
 


### PR DESCRIPTION
By odd I mean that the new version found appears to be older than the
last version we had (ie: upstream released a version 2 after having
released a version 3).

This should help fixing https://github.com/fedora-infra/anitya/issues/66