### PR TITLE
Run exact match search by default but add button to extend it

### DIFF
--- a/anitya/lib/backends/custom.py
+++ b/anitya/lib/backends/custom.py
@@ -68,7 +68,7 @@ class CustomBackend(BaseBackend):
         if project.regex:
             regex = REGEX_ALIASES.get(project.regex, project.regex)
 
-        if '%{name}' in regex:
+        if '%(name)' in regex:
             regex = regex % {'name': project.name.replace('+', '\+')}
 
         return get_versions_by_regex(

--- a/anitya/lib/model.py
+++ b/anitya/lib/model.py
@@ -528,17 +528,31 @@ class Project(BASE):
 
         query1 = session.query(
             cls
-        ).filter(
-            Project.name.ilike(pattern)
         )
+
+        if '%' in pattern:
+            query1 = query1.filter(
+                Project.name.ilike(pattern)
+            )
+        else:
+            query1 = query1.filter(
+                Project.name == pattern
+            )
 
         query2 = session.query(
             cls
         ).filter(
             Project.id == Packages.project_id
-        ).filter(
-            Packages.package_name.ilike(pattern)
         )
+
+        if '%' in pattern:
+            query2 = query2.filter(
+                Packages.package_name.ilike(pattern)
+            )
+        else:
+            query2 = query2.filter(
+                Packages.package_name == pattern
+            )
 
         if distro is not None:
             query1 = query1.filter(

--- a/anitya/templates/search.html
+++ b/anitya/templates/search.html
@@ -47,7 +47,8 @@
             class="SearchBox" value="{{ pattern }}"/>
         <button type="submit" class="btn btn-default">Search</button>
         {% if pattern != extended_pattern %}
-        <a href="{{ url_for('projects_search', pattern=extended_pattern) }}">
+        <a href="{{ url_for('projects_search', pattern=extended_pattern) }}"
+            title="Extend the search by searching for {{ extended_pattern }}">
             <button type="button" class="btn btn-default">Extend</button>
         </a>
         {% endif %}

--- a/anitya/templates/search.html
+++ b/anitya/templates/search.html
@@ -46,9 +46,11 @@
         <input type="text" name="pattern" placeholder="Project name"
             class="SearchBox" value="{{ pattern }}"/>
         <button type="submit" class="btn btn-default">Search</button>
+        {% if pattern != extended_pattern %}
         <a href="{{ url_for('projects_search', pattern=extended_pattern) }}">
             <button type="button" class="btn btn-default">Extend</button>
         </a>
+        {% endif %}
       </div>
     </form>
   </div>

--- a/anitya/templates/search.html
+++ b/anitya/templates/search.html
@@ -43,8 +43,12 @@
     <form action="{{ url_for('projects_search') }}" role="form">
     {% endif %}
       <div class="form-group">
-        <input type="text" name="pattern" placeholder="Project name" class="SearchBox" value="{{ pattern }}"/>
+        <input type="text" name="pattern" placeholder="Project name"
+            class="SearchBox" value="{{ pattern }}"/>
         <button type="submit" class="btn btn-default">Search</button>
+        <a href="{{ url_for('projects_search', pattern=extended_pattern) }}">
+            <button type="button" class="btn btn-default">Extend</button>
+        </a>
       </div>
     </form>
   </div>

--- a/anitya/templates/search.html
+++ b/anitya/templates/search.html
@@ -46,12 +46,6 @@
         <input type="text" name="pattern" placeholder="Project name"
             class="SearchBox" value="{{ pattern }}"/>
         <button type="submit" class="btn btn-default">Search</button>
-        {% if pattern != extended_pattern %}
-        <a href="{{ url_for('projects_search', pattern=extended_pattern) }}"
-            title="Extend the search by searching for {{ extended_pattern }}">
-            <button type="button" class="btn btn-default">Extend</button>
-        </a>
-        {% endif %}
       </div>
     </form>
   </div>

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -219,9 +219,6 @@ def projects_search(pattern=None):
     pattern = flask.request.args.get('pattern', pattern) or '*'
     page = flask.request.args.get('page', 1)
 
-    if '*' not in pattern:
-        pattern += '*'
-
     try:
         page = int(page)
     except ValueError:

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -255,9 +255,6 @@ def distro_projects_search(distroname, pattern=None):
     pattern = flask.request.args.get('pattern', pattern) or '*'
     page = flask.request.args.get('page', 1)
 
-    if '*' not in pattern:
-        pattern += '*'
-
     try:
         page = int(page)
     except ValueError:

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -12,6 +12,20 @@ import anitya.lib.model
 from anitya.app import APP, SESSION, login_required, load_docs
 
 
+def get_extended_pattern(pattern):
+    ''' For a given pattern `p` return it so that it looks like `*p*`
+    adjusting it accordingly.
+    '''
+
+    if not pattern.startswith('*') and not pattern.endswith('*'):
+        pattern += '*'
+    elif not pattern.startswith('*') and pattern.endswith('*'):
+        pattern = '*' + pattern
+    elif pattern.startswith('*') and not pattern.endswith('*'):
+        pattern += '*'
+    return pattern
+
+
 @APP.route('/')
 def index():
     total = anitya.lib.model.Project.all(SESSION, count=True)

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -237,10 +237,10 @@ def projects_search(pattern=None):
 
     total_page = int(ceil(projects_count / float(50)))
     extended_pattern = pattern
-    if not extended_pattern.startswith('*'):
-        extended_pattern = '*' + extended_pattern
-    if not extended_pattern.endswith('*'):
+    if not extended_pattern.startswith('*') and not extended_pattern.endswith('*'):
         extended_pattern += '*'
+    elif not extended_pattern.startswith('*') and extended_pattern.endswith('*'):
+        extended_pattern = '*' + extended_pattern
 
     return flask.render_template(
         'search.html',
@@ -279,10 +279,10 @@ def distro_projects_search(distroname, pattern=None):
 
     total_page = int(ceil(projects_count / float(50)))
     extended_pattern = pattern
-    if not extended_pattern.startswith('*'):
-        extended_pattern = '*' + extended_pattern
-    if not extended_pattern.endswith('*'):
+    if not extended_pattern.startswith('*') and not extended_pattern.endswith('*'):
         extended_pattern += '*'
+    elif not extended_pattern.endswith('*') and extended_pattern.endswith('*'):
+        extended_pattern = '*' + extended_pattern
 
     return flask.render_template(
         'search.html',

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -241,6 +241,8 @@ def projects_search(pattern=None):
         extended_pattern += '*'
     elif not extended_pattern.startswith('*') and extended_pattern.endswith('*'):
         extended_pattern = '*' + extended_pattern
+    elif extended_pattern.startswith('*') and not extended_pattern.endswith('*'):
+        extended_pattern += '*'
 
     return flask.render_template(
         'search.html',
@@ -283,6 +285,8 @@ def distro_projects_search(distroname, pattern=None):
         extended_pattern += '*'
     elif not extended_pattern.endswith('*') and extended_pattern.endswith('*'):
         extended_pattern = '*' + extended_pattern
+    elif extended_pattern.startswith('*') and not extended_pattern.endswith('*'):
+        extended_pattern += '*'
 
     return flask.render_template(
         'search.html',

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -232,6 +232,7 @@ def projects_search(pattern=None):
 
     pattern = flask.request.args.get('pattern', pattern) or '*'
     page = flask.request.args.get('page', 1)
+    exact = flask.request.args.get('exact', 0)
 
     try:
         page = int(page)
@@ -243,15 +244,16 @@ def projects_search(pattern=None):
     projects_count = anitya.lib.model.Project.search(
         SESSION, pattern=pattern, count=True)
 
-    # Extends the search
-    projects.extend(
-        anitya.lib.model.Project.search(
-            SESSION,
-            pattern=get_extended_pattern(pattern),
-            page=page)
-        )
-    projects_count += anitya.lib.model.Project.search(
-        SESSION, pattern=get_extended_pattern(pattern), count=True)
+    if not str(exact).lower() in ['1', 'true']:
+        # Extends the search
+        projects.extend(
+            anitya.lib.model.Project.search(
+                SESSION,
+                pattern=get_extended_pattern(pattern),
+                page=page)
+            )
+        projects_count += anitya.lib.model.Project.search(
+            SESSION, pattern=get_extended_pattern(pattern), count=True)
 
     if projects_count == 1 and projects[0].name == pattern.replace('*', ''):
         flask.flash(
@@ -278,6 +280,7 @@ def distro_projects_search(distroname, pattern=None):
 
     pattern = flask.request.args.get('pattern', pattern) or '*'
     page = flask.request.args.get('page', 1)
+    exact = flask.request.args.get('exact', 0)
 
     try:
         page = int(page)
@@ -289,18 +292,19 @@ def distro_projects_search(distroname, pattern=None):
     projects_count = anitya.lib.model.Project.search(
         SESSION, pattern=pattern, distro=distroname, count=True)
 
-    # Extends the search
-    projects.extend(
-        anitya.lib.model.Project.search(
+    if not str(exact).lower() in ['1', 'true']:
+        # Extends the search
+        projects.extend(
+            anitya.lib.model.Project.search(
+                SESSION,
+                pattern=get_extended_pattern(pattern),
+                distro=distroname,
+                page=page)
+            )
+        projects_count += anitya.lib.model.Project.search(
             SESSION,
             pattern=get_extended_pattern(pattern),
-            distro=distroname,
-            page=page)
-        )
-    projects_count += anitya.lib.model.Project.search(
-        SESSION,
-        pattern=get_extended_pattern(pattern),
-        distro=distroname, count=True)
+            distro=distroname, count=True)
 
     if projects_count == 1 and projects[0].name == pattern.replace('*', ''):
         flask.flash(

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -243,6 +243,16 @@ def projects_search(pattern=None):
     projects_count = anitya.lib.model.Project.search(
         SESSION, pattern=pattern, count=True)
 
+    # Extends the search
+    projects.extend(
+        anitya.lib.model.Project.search(
+            SESSION,
+            pattern=get_extended_pattern(pattern),
+            page=page)
+        )
+    projects_count += anitya.lib.model.Project.search(
+        SESSION, pattern=get_extended_pattern(pattern), count=True)
+
     if projects_count == 1 and projects[0].name == pattern.replace('*', ''):
         flask.flash(
             'Only one result matching with an exact match, redirecting')
@@ -250,19 +260,11 @@ def projects_search(pattern=None):
             flask.url_for('project', project_id=projects[0].id))
 
     total_page = int(ceil(projects_count / float(50)))
-    extended_pattern = pattern
-    if not extended_pattern.startswith('*') and not extended_pattern.endswith('*'):
-        extended_pattern += '*'
-    elif not extended_pattern.startswith('*') and extended_pattern.endswith('*'):
-        extended_pattern = '*' + extended_pattern
-    elif extended_pattern.startswith('*') and not extended_pattern.endswith('*'):
-        extended_pattern += '*'
 
     return flask.render_template(
         'search.html',
         current='projects',
         pattern=pattern,
-        extended_pattern=extended_pattern,
         projects=projects,
         total_page=total_page,
         projects_count=projects_count,
@@ -287,6 +289,19 @@ def distro_projects_search(distroname, pattern=None):
     projects_count = anitya.lib.model.Project.search(
         SESSION, pattern=pattern, distro=distroname, count=True)
 
+    # Extends the search
+    projects.extend(
+        anitya.lib.model.Project.search(
+            SESSION,
+            pattern=get_extended_pattern(pattern),
+            distro=distroname,
+            page=page)
+        )
+    projects_count += anitya.lib.model.Project.search(
+        SESSION,
+        pattern=get_extended_pattern(pattern),
+        distro=distroname, count=True)
+
     if projects_count == 1 and projects[0].name == pattern.replace('*', ''):
         flask.flash(
             'Only one result matching with an exact match, redirecting')
@@ -294,19 +309,11 @@ def distro_projects_search(distroname, pattern=None):
             flask.url_for('project', project_id=projects[0].id))
 
     total_page = int(ceil(projects_count / float(50)))
-    extended_pattern = pattern
-    if not extended_pattern.startswith('*') and not extended_pattern.endswith('*'):
-        extended_pattern += '*'
-    elif not extended_pattern.endswith('*') and extended_pattern.endswith('*'):
-        extended_pattern = '*' + extended_pattern
-    elif extended_pattern.startswith('*') and not extended_pattern.endswith('*'):
-        extended_pattern += '*'
 
     return flask.render_template(
         'search.html',
         current='projects',
         pattern=pattern,
-        extended_pattern=extended_pattern,
         projects=projects,
         distroname=distroname,
         total_page=total_page,

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -236,11 +236,17 @@ def projects_search(pattern=None):
             flask.url_for('project', project_id=projects[0].id))
 
     total_page = int(ceil(projects_count / float(50)))
+    extended_pattern = pattern
+    if not extended_pattern.startswith('*'):
+        extended_pattern = '*' + extended_pattern
+    if not extended_pattern.endswith('*'):
+        extended_pattern += '*'
 
     return flask.render_template(
         'search.html',
         current='projects',
         pattern=pattern,
+        extended_pattern=extended_pattern,
         projects=projects,
         total_page=total_page,
         projects_count=projects_count,
@@ -272,11 +278,17 @@ def distro_projects_search(distroname, pattern=None):
             flask.url_for('project', project_id=projects[0].id))
 
     total_page = int(ceil(projects_count / float(50)))
+    extended_pattern = pattern
+    if not extended_pattern.startswith('*'):
+        extended_pattern = '*' + extended_pattern
+    if not extended_pattern.endswith('*'):
+        extended_pattern += '*'
 
     return flask.render_template(
         'search.html',
         current='projects',
         pattern=pattern,
+        extended_pattern=extended_pattern,
         projects=projects,
         distroname=distroname,
         total_page=total_page,

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -219,7 +219,10 @@ a backend for the project hosting. More information below.</p>"""
 
         output = self.app.get('/projects/search/g')
         self.assertEqual(output.status_code, 200)
+        self.assertEqual(output.data.count('<a href="/project/'), 0)
 
+        output = self.app.get('/projects/search/g*')
+        self.assertEqual(output.status_code, 200)
         expected = """
                   <a href="http://www.geany.org/" target="_blank">
                     http://www.geany.org/


### PR DESCRIPTION
By default anitya will now do exact match searches on project and package name.
If there is only one result, the user will be redirected to its page.

If there are more than one result, the user will be presented with a button entitled ``Extend`` offering the possibility to extend the search.