### PR TITLE
When retrieving the latest version for the GNOME backend, try first cache.json

### DIFF
--- a/anitya/lib/backends/gnome.py
+++ b/anitya/lib/backends/gnome.py
@@ -68,7 +68,13 @@ class GnomeBackend(BaseBackend):
             when the version cannot be retrieved correctly
 
         '''
-        return cls.get_ordered_versions(project)[-1]
+        try:
+            # First try to get the version by using the cache.json file and
+            # assume the ordering will always be the right one
+            return use_gnome_cache_json(project)[-1]
+        except Exception as err:
+            # Otherwise we rely on our sorting method
+            return cls.get_ordered_versions(project)[-1]
 
     @classmethod
     def get_versions(cls, project):


### PR DESCRIPTION
Assuming the odering of the version numbers on the cache.json file is always
correct, we first try it, then if we there are no cache.json, we get the list of
versions in a different way and rely on our sorting.

Should fix behavior such as:
https://bugzilla.redhat.com/show_bug.cgi?id=1034056#c6
where we went backward