### PR TITLE
fix GitHub capitalization

### DIFF
--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -108,8 +108,8 @@
     if (str == 'folder'){
       $('#version_url_row').show();
     };
-    if (str == 'Github'){
-        $("label[for='version_url']").text('Github owner/project');
+    if (str == 'GitHub'){
+        $("label[for='version_url']").text('GitHub owner/project');
         $('#version_url_row').show();
     };
     if (str == 'Packagist'){

--- a/files/migrate_wiki.py
+++ b/files/migrate_wiki.py
@@ -160,7 +160,7 @@ def migrate_wiki(agent):
         )
         if backend == 'custom':
             project.version_url = url
-        if backend == 'Github':
+        if backend == 'GitHub':
             project.version_url = (name or pkg.name)
 
         try:


### PR DESCRIPTION
This should fix isse #131. It appears that commit a5a3ba878ff8f2f58b75f315fbb36d30ce33de85 broke github by changing the capitalizion in the github backend but not in all references to is.