### PR TITLE
Adjust the default regex to ignore .asc in filename

### DIFF
--- a/anitya/lib/backends/__init__.py
+++ b/anitya/lib/backends/__init__.py
@@ -22,7 +22,7 @@ from anitya.lib.exceptions import AnityaPluginException
 
 
 REGEX = b'%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?i)(?:[-_]'\
-    '(?:minsrc|src|source))?\.(?:tar|t[bglx]z|tbz2|zip)'
+    '(?:minsrc|src|source|asc))?\.(?:tar|t[bglx]z|tbz2|zip)'
 
 
 def upstream_cmp(v1, v2):

--- a/anitya/lib/backends/__init__.py
+++ b/anitya/lib/backends/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
- (c) 2014 - Copyright Red Hat Inc
+ (c) 2014-2015 - Copyright Red Hat Inc
 
  Authors:
    Pierre-Yves Chibon <pingou@pingoured.fr>


### PR DESCRIPTION
These are used when tarball are GPG signed when released and can lead to
false positive in versions found.

Fixes https://github.com/fedora-infra/anitya/issues/136