### PR TITLE
Fix mapping of a project on an existing package

### DIFF
--- a/anitya/lib/__init__.py
+++ b/anitya/lib/__init__.py
@@ -209,7 +209,7 @@ def map_project(
     # Check that we can update the mapping to the new info provided
     other_pkg = anitya.lib.model.Packages.by_package_name_distro(
         session, package_name, distro)
-    if other_pkg:
+    if other_pkg and other_pkg.project:
         raise anitya.lib.exceptions.AnityaInvalidMappingException(
                 pkgname, distro, package_name, distribution,
                 other_pkg.project.id, other_pkg.project.name)
@@ -217,11 +217,15 @@ def map_project(
     edited = None
     if not pkg:
         topic = 'project.map.new'
-        pkg = anitya.lib.model.Packages(
-            distro=distro_obj.name,
-            project_id=project.id,
-            package_name=package_name
-        )
+        if not other_pkg:
+            pkg = anitya.lib.model.Packages(
+                distro=distro_obj.name,
+                project_id=project.id,
+                package_name=package_name
+            )
+        else:
+            other_pkg.project = project
+            pkg = other_pkg
     else:
         topic = 'project.map.update'
         edited = []


### PR DESCRIPTION
Currently, when a mapping is removed, we do not delete the package as
there might be other project mapping to it (for example one packages
built from several sources).
This means that we can have packages not linked to any project.
So we should support mapping a project to this package and this is what
this commit is doing.