### PR TITLE
Invert the name and SF name in the SourceForge backend.

### DIFF
--- a/anitya/lib/backends/sourceforge.py
+++ b/anitya/lib/backends/sourceforge.py
@@ -57,9 +57,11 @@ class SourceforgeBackend(BaseBackend):
         '''
         url_template = 'http://sourceforge.net/projects/%(name)s/rss?limit=200'
 
-        url = url_template % {'name': project.name}
-        regex = REGEX % {
+        url = url_template % {
             'name': (project.version_url or project.name).replace('+', '\+')
+        }
+        regex = REGEX % {
+            'name': project.name.replace('+', '\+')
         }
 
         return get_versions_by_regex(url, regex, project)


### PR DESCRIPTION
Until now we were using the name field as the name of the project on SF,
so sf.net/<project>. But this causes problems when the project releases
a tarball with a different name than their project name, so we introduced
the SF name, aimed to be the name of the tarball on SF.
However, this does not cover the projects releasing multiple tarball.

In anitya project and homepage are required to be unique, so a project
releasing multiple tarballs under the same project/homepage was a
problem.

By inverting the project name and the SF name we can solve this.

From now on: the project name is the name of the tarball to search in the
RSS page and the SF name is the name of the project on SourceForge.

Fixes https://github.com/fedora-infra/anitya/issues/80
Fixes https://github.com/fedora-infra/anitya/issues/146