### PR TITLE
Use versions API.

### DIFF
--- a/anitya/lib/backends/rubygems.py
+++ b/anitya/lib/backends/rubygems.py
@@ -56,7 +56,7 @@ class RubygemsBackend(BaseBackend):
             when the versions cannot be retrieved correctly
 
         '''
-        url = 'http://rubygems.org/api/v1/gems/%(name)s.json' % {
+        url = 'http://rubygems.org/api/v1/versions/%(name)s/latest.json' % {
             'name': project.name}
 
         try:


### PR DESCRIPTION
This should improve performance a bit, since just version and nothing
else is returned.

http://guides.rubygems.org/rubygems-org-api/#get---apiv1versionsgem-namelatestjson

Please note that I have not tested this, so hopefully this does not break anything ;)