### PR TITLE
add haskell Stackage backend

### DIFF
--- a/anitya/docs/about.rst
+++ b/anitya/docs/about.rst
@@ -53,6 +53,8 @@ The backends available are:
   `rubygems.org <http://rubygems.org/>`_
 * ``sourceforge.py`` for projects hosted on
   `sourceforge.net <http://sourceforge.net/>`_
+* ``stackage.py`` for projects hosted on
+  `www.stackage.org <https://www.stackage.org/>`_
 
 If your project cannot be used with any of these backend you can always try
 the ``custom`` backend.

--- a/anitya/lib/backends/stackage.py
+++ b/anitya/lib/backends/stackage.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+"""
+ (c) 2014-2015 - Copyright Red Hat Inc
+ Authors:
+   Pierre-Yves Chibon <pingou@pingoured.fr>
+   Jens Petersen <petersen@redhat.com>
+"""
+
+
+from anitya.lib.backends import BaseBackend, get_versions_by_regex, REGEX
+
+
+class StackageBackend(BaseBackend):
+    ''' The custom class for Haskell projects hosted on Stackage.org.
+    This backend allows to specify a version_url and a regex that will
+    be used to retrieve the version information.
+    '''
+
+    name = 'Stackage'
+    examples = [
+        'https://www.stackage.org/package/conduit',
+        'https://www.stackage.org/package/cabal-install',
+    ]
+
+    @classmethod
+    def get_version(cls, project):
+        ''' Method called to retrieve the latest version of the projects
+        provided, project that relies on the backend of this plugin.
+        :arg Project project: a :class:`model.Project` object whose backend
+            corresponds to the current plugin.
+        :return: the latest version found upstream
+        :return type: str
+        :raise AnityaPluginException: a
+            :class:`anitya.lib.exceptions.AnityaPluginException` exception
+            when the version cannot be retrieved correctly
+        '''
+        return cls.get_ordered_versions(project)[-1]
+
+    @classmethod
+    def get_versions(cls, project):
+        ''' Method called to retrieve all the versions (that can be found)
+        of the projects provided, project that relies on the backend of
+        this plugin.
+        :arg Project project: a :class:`model.Project` object whose backend
+            corresponds to the current plugin.
+        :return: a list of all the possible releases found
+        :return type: list
+        :raise AnityaPluginException: a
+            :class:`anitya.lib.exceptions.AnityaPluginException` exception
+            when the versions cannot be retrieved correctly
+        '''
+        url = 'https://www.stackage.org/package/%(name)s' % {
+            'name': project.name}
+
+        regex = '%(name)s <span class="latest-version">([\d.]*) ' % {'name': project.name}
+
+        return get_versions_by_regex(url, regex, project)

--- a/anitya/lib/backends/stackage.py
+++ b/anitya/lib/backends/stackage.py
@@ -53,6 +53,6 @@ class StackageBackend(BaseBackend):
         url = 'https://www.stackage.org/package/%(name)s' % {
             'name': project.name}
 
-        regex = '%(name)s <span class="latest-version">([\d.]*) ' % {'name': project.name}
+        regex = '%(name)s <span class="latest-version">([\d.]*) *</span>' % {'name': project.name}
 
         return get_versions_by_regex(url, regex, project)

--- a/anitya/lib/backends/stackage.py
+++ b/anitya/lib/backends/stackage.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 
 """
- (c) 2014-2015 - Copyright Red Hat Inc
+ (c) 2015 - Copyright Red Hat Inc
  Authors:
-   Pierre-Yves Chibon <pingou@pingoured.fr>
    Jens Petersen <petersen@redhat.com>
 """
 

--- a/tests/test_backend_stackage.py
+++ b/tests/test_backend_stackage.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions
+# of the GNU General Public License v.2, or (at your option) any later
+# version.  This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.  You
+# should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# Any Red Hat trademarks that are incorporated in the source
+# code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission
+# of Red Hat, Inc.
+#
+
+'''
+anitya tests for the custom backend.
+'''
+
+__requires__ = ['SQLAlchemy >= 0.7']
+import pkg_resources
+
+import json
+import unittest
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(
+    os.path.abspath(__file__)), '..'))
+
+import anitya.lib.backends.stackage as backend
+import anitya.lib.model as model
+from anitya.lib.exceptions import AnityaPluginException
+from tests import Modeltests, create_distro, skip_jenkins
+
+
+BACKEND = 'Stackage'
+
+
+class HackageBackendtests(Modeltests):
+    """ Hackage backend tests. """
+
+    @skip_jenkins
+    def setUp(self):
+        """ Set up the environnment, ran before every tests. """
+        super(HackageBackendtests, self).setUp()
+
+        create_distro(self.session)
+        self.create_project()
+
+    def create_project(self):
+        """ Create some basic projects to work with. """
+        project = model.Project(
+            name='cpphs',
+            homepage='https://www.stackage.org/package/cpphs',
+            backend=BACKEND,
+        )
+        self.session.add(project)
+        self.session.commit()
+
+        project = model.Project(
+            name='foobar',
+            homepage='https://www.stackage.org/package/foobar',
+            backend=BACKEND,
+        )
+        self.session.add(project)
+        self.session.commit()
+
+
+    def test_get_version(self):
+        """ Test the get_version function of the custom backend. """
+        pid = 1
+        project = model.Project.get(self.session, pid)
+        exp = '1.19'
+        obs = backend.HackageBackend.get_version(project)
+        self.assertEqual(obs, exp)
+
+        pid = 2
+        project = model.Project.get(self.session, pid)
+        self.assertRaises(
+            AnityaPluginException,
+            backend.HackageBackend.get_version,
+            project
+        )
+
+
+    def test_get_versions(self):
+        """ Test the get_versions function of the custom backend. """
+        pid = 1
+        project = model.Project.get(self.session, pid)
+        exp = ['1.19']
+        obs = backend.HackageBackend.get_ordered_versions(project)
+        self.assertEqual(obs, exp)
+
+        pid = 2
+        project = model.Project.get(self.session, pid)
+        self.assertRaises(
+            AnityaPluginException,
+            backend.HackageBackend.get_version,
+            project
+        )
+
+
+if __name__ == '__main__':
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(HackageBackendtests)
+    unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -49,7 +49,7 @@ class Pluginstests(Modeltests):
             'CPAN (perl)', 'Debian project', 'Drupal6', 'Drupal7', 'Freshmeat',
             'GNOME', 'GNU project', 'GitHub', 'Google code', 'Hackage',
             'Launchpad', 'Maven Central', 'PEAR', 'PECL', 'Packagist', 'PyPI',
-            'Rubygems', 'Sourceforge', 'custom', 'folder', 'npmjs',
+            'Rubygems', 'Sourceforge', 'custom', 'folder', 'npmjs', 'Stackage'
         ]
 
         self.assertEqual(sorted(plgns), exp)
@@ -62,7 +62,7 @@ class Pluginstests(Modeltests):
             'CPAN (perl)', 'Debian project', 'Drupal6', 'Drupal7', 'Freshmeat',
             'GNOME', 'GNU project', 'GitHub', 'Google code', 'Hackage',
             'Launchpad', 'Maven Central', 'PEAR', 'PECL', 'Packagist', 'PyPI',
-            'Rubygems', 'Sourceforge', 'custom', 'folder', 'npmjs',
+            'Rubygems', 'Sourceforge', 'custom', 'folder', 'npmjs', 'Stackage'
         ]
 
         self.assertEqual(sorted(plgns), exp)


### PR DESCRIPTION
This adds a new backend for Stackage (stable Haskell packages).

Stackage is a stabler subset of Hackage which we want to use for
Fedora Haskell package tracking when available.
(Not all Fedora Haskell packages are in Stackage though so we still need the Hackage backend too.)

This is derived from hackage.py.

I guess some test(s) needed too, if this looks ok?  Anything else?