### PR TITLE
Make the anitya_cron multithreaded and drop support for the progress-bar

### DIFF
--- a/files/anitya_cron.py
+++ b/files/anitya_cron.py
@@ -11,16 +11,17 @@ import anitya.app
 import anitya.lib.exceptions
 import anitya.lib.model
 
+LOG = logging.getLogger('anitya')
 
 def update_project(project):
     """ Check for updates on the specified project. """
-    print(project.name)
+    LOG.info(project.name)
     session = anitya.lib.init(anitya.app.APP.config['DB_URL'])
     project = anitya.lib.model.Project.by_id(session, project.id)
     try:
         anitya.check_release(project, session),
     except anitya.lib.exceptions.AnityaException as err:
-        print(err)
+        LOG.info(err)
     finally:
         session.get_bind().dispose()
         session.remove()
@@ -31,7 +32,6 @@ def main(debug):
     version.
     '''
     session = anitya.app.SESSION
-    LOG = logging.getLogger('anitya')
     LOG.setLevel(logging.DEBUG)
 
     formatter = logging.Formatter(


### PR DESCRIPTION
With this version, using 10 threads running the cron drops from 90minutes
to less than 10 minutes.