### PR TITLE
Handle flags not pointing to a project

### DIFF
--- a/anitya/templates/flags.html
+++ b/anitya/templates/flags.html
@@ -128,7 +128,11 @@
         <td>
             {{ flag.created_on.strftime('%Y-%m-%d %H:%M:%S') }}
         </td>
-        <td> <a href="{{ url_for('project', project_id=flag.project.id) }}">{{ flag.project.name }}</a> </td>
+        <td>
+          {% if flag.project -%}
+          <a href="{{ url_for('project', project_id=flag.project.id) }}">{{ flag.project.name }}</a>
+          {%- endif %}
+        </td>
         <td> {{ flag.user }} </td>
         <td> {{ flag.reason }} </td>
     </tr>


### PR DESCRIPTION
When processing a flag we might end-up deleting the project it is
associated, in which case the template breaks if we do not check
if there is a project before displaying it