### PR TITLE
Stackage: change regexp to track LTS Haskell

### DIFF
--- a/anitya/lib/backends/stackage.py
+++ b/anitya/lib/backends/stackage.py
@@ -52,6 +52,6 @@ class StackageBackend(BaseBackend):
         url = 'https://www.stackage.org/package/%(name)s' % {
             'name': project.name}
 
-        regex = '%(name)s <span class="latest-version">([\d.]*) *</span>' % {'name': project.name}
+        regex = '<a href="https://www.stackage.org/lts-[\d.]*">LTS Haskell [\d.]* - GHC 7.8.4 ([\d.]*)</a>'
 
         return get_versions_by_regex(url, regex, project)

--- a/anitya/lib/backends/stackage.py
+++ b/anitya/lib/backends/stackage.py
@@ -52,6 +52,6 @@ class StackageBackend(BaseBackend):
         url = 'https://www.stackage.org/package/%(name)s' % {
             'name': project.name}
 
-        regex = '<a href="https://www.stackage.org/lts-[\d.]*">LTS Haskell [\d.]* - GHC 7.8.4 ([\d.]*)</a>'
+        regex = '<a href="https://www.stackage.org/lts-[\d.]*">LTS Haskell [\d.]* - GHC 7.8.4 \(([\d.]*)\)</a>'
 
         return get_versions_by_regex(url, regex, project)


### PR DESCRIPTION
previous regexp was not tracking nightly but actually very latest package in Hackage!