### PR TITLE
Return the actually error message to the UI

### DIFF
--- a/anitya/lib/backends/__init__.py
+++ b/anitya/lib/backends/__init__.py
@@ -275,7 +275,8 @@ def get_versions_by_regex(url, regex, project, insecure=False):
     except Exception, err:
         anitya.LOG.debug('%s ERROR: %s' % (project.name, err.message))
         raise AnityaPluginException(
-            'Could not call : "%s" of "%s"' % (url, project.name))
+            'Could not call : "%s" of "%s", with error: %s' % (
+                url, project.name, err.message))
 
     if not isinstance(req, basestring):
         req = req.text


### PR DESCRIPTION
This will help getting a better understand of what is going on and why
retrieving the release failed.