### PR TITLE
Added column for latest version in search page

### DIFF
--- a/anitya/templates/search.html
+++ b/anitya/templates/search.html
@@ -72,6 +72,11 @@
                     {{ project.homepage }}
                   </a>
                 </td>
+                <td>
+                  {% if project.latest_version %}
+                    {{ project.latest_version }}
+                  {% endif %}
+                </td>
               </tr>
             {% endfor %}
             </table>


### PR DESCRIPTION
Tried to Fix #186 
At present, there is no column for latest version of projects in the search page.