### PR TITLE
Add the possibility to separate odd updates vs failed updates

### DIFF
--- a/anitya/lib/model.py
+++ b/anitya/lib/model.py
@@ -451,7 +451,15 @@ class Project(BASE):
             query = query.filter(
                 Project.logs != None,
                 Project.logs != 'Version retrieved correctly',
+                ~Project.logs.ilike('Something strange occured%'),
             )
+        elif status == 'odd':
+            query = query.filter(
+                Project.logs != None,
+                Project.logs != 'Version retrieved correctly',
+                Project.logs.ilike('Something strange occured%'),
+            )
+
         elif status == 'new':
             query = query.filter(
                 Project.logs == None,
@@ -614,7 +622,7 @@ class ProjectFlag(BASE):
         ).order_by(ProjectFlag.created_on)
 
         return query.all()
-    
+
     @classmethod
     def search(cls, session, project_name=None, from_date=None, user=None,
                state=None, limit=None, offset=None, count=False):

--- a/anitya/templates/master.html
+++ b/anitya/templates/master.html
@@ -77,6 +77,11 @@
                     <a href="{{url_for('projects_updated')}}">Updated</a>
                   </li>
                   <li>
+                    <a href="{{url_for('projects_updated', status='odd')}}">
+                      Odd version found
+                    </a>
+                  </li>
+                  <li>
                     <a href="{{url_for('projects_updated', status='new')}}">
                       Not updated
                     </a>

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -140,7 +140,7 @@ def projects_updated(status='updated'):
     except ValueError:
         page = 1
 
-    statuses = ['new', 'updated', 'failed', 'never_updated']
+    statuses = ['new', 'updated', 'failed', 'never_updated', 'odd']
 
     if status not in statuses:
         flask.flash(


### PR DESCRIPTION
Odd updates are projects for which we find a new version that we find to
be inferior to the latest update we had.
Failed updates are plain failure to retrieve the newest update.