### PR TITLE
Fix GitHub backend upstream detection

### DIFF
--- a/anitya/lib/backends/github.py
+++ b/anitya/lib/backends/github.py
@@ -28,6 +28,20 @@ class GithubBackend(BaseBackend):
         'https://github.com/fedora-infra/pkgdb2',
     ]
 
+    def get_url_from_regex_match(cls, regex_match):
+        url_template = 'https://github.com/{}/tags'
+
+        repo_owner = regex_match.group(1)
+        repo_name = regex_match.group(2)
+
+        url = url_template.format(
+            "{}/{}".format(
+                repo_owner, repo_name
+            )
+        )
+
+        return url
+
     @classmethod
     def get_version(cls, project):
         ''' Method called to retrieve the latest version of the projects
@@ -59,15 +73,26 @@ class GithubBackend(BaseBackend):
             when the versions cannot be retrieved correctly
 
         '''
+        github_repo_regex = 'http[s]?:\/\/github\.com\/([^\/]+)\/([^\/]+)[\/]?'
+
+        homepage_gh_regex_match = re.match(github_repo_regex, project.homepage)
+
         if project.version_url:
-            url_template = 'https://github.com/%(version_url)s/tags'
-            version_url = project.version_url.replace('https://github.com/', '')
-            url = url_template % {'version_url': version_url}
-        elif project.homepage.startswith('https://github.com'):
-            url = project.homepage
-            if url.endswith('/'):
-                url = project.homepage[:1]
-            url += '/tags'
+            matched_url_regex = re.match(github_repo_regex, project.version_url)
+            if matched_url_regex:
+                # matches github repo url
+                # e.g https://github.com/fedora-infra/anitya
+                url = cls.get_url_from_regex_match(matched_url_regex)
+            else:
+                # does not match github repo url,
+                # assume repoowner/reponame format
+                # e.g fedora-infra/anitya
+                url = url_template.format(project.version_url)
+
+        elif homepage_gh_regex_match:
+            # homepage matches github repo regex
+            url = cls.get_url_from_regex_match(homepage_gh_regex_match)
+
         else:
             raise AnityaPluginException(
                 'Project %s was incorrectly set-up' % project.name)

--- a/anitya/lib/backends/github.py
+++ b/anitya/lib/backends/github.py
@@ -1,18 +1,33 @@
 # -*- coding: utf-8 -*-
 
 """
- (c) 2014 - Copyright Red Hat Inc
+ (c) 2016 - Copyright Red Hat Inc
 
  Authors:
    Pierre-Yves Chibon <pingou@pingoured.fr>
+   Chaoyi Zha <cydrobolt@fedoraproject.org>
 
 """
 
 from anitya.lib.backends import BaseBackend, get_versions_by_regex
 from anitya.lib.exceptions import AnityaPluginException
+import re
 
 
 REGEX = b'class="tag-name">([^<]*)</span'
+url_template = 'https://github.com/{}/tags'
+
+def get_url_from_regex_match(regex_match):
+    repo_owner = regex_match.group(1)
+    repo_name = regex_match.group(2)
+
+    url = url_template.format(
+        "{}/{}".format(
+            repo_owner, repo_name
+        )
+    )
+
+    return url
 
 
 class GithubBackend(BaseBackend):
@@ -27,20 +42,6 @@ class GithubBackend(BaseBackend):
         'https://github.com/fedora-infra/fedocal',
         'https://github.com/fedora-infra/pkgdb2',
     ]
-
-    def get_url_from_regex_match(cls, regex_match):
-        url_template = 'https://github.com/{}/tags'
-
-        repo_owner = regex_match.group(1)
-        repo_name = regex_match.group(2)
-
-        url = url_template.format(
-            "{}/{}".format(
-                repo_owner, repo_name
-            )
-        )
-
-        return url
 
     @classmethod
     def get_version(cls, project):
@@ -82,7 +83,7 @@ class GithubBackend(BaseBackend):
             if matched_url_regex:
                 # matches github repo url
                 # e.g https://github.com/fedora-infra/anitya
-                url = cls.get_url_from_regex_match(matched_url_regex)
+                url = get_url_from_regex_match(matched_url_regex)
             else:
                 # does not match github repo url,
                 # assume repoowner/reponame format
@@ -91,7 +92,7 @@ class GithubBackend(BaseBackend):
 
         elif homepage_gh_regex_match:
             # homepage matches github repo regex
-            url = cls.get_url_from_regex_match(homepage_gh_regex_match)
+            url = get_url_from_regex_match(homepage_gh_regex_match)
 
         else:
             raise AnityaPluginException(

--- a/anitya/templates/project.html
+++ b/anitya/templates/project.html
@@ -204,7 +204,11 @@
 
 {% block jscript %}
 <script>
-  function checkrelease(test=false){
+  function checkrelease(test){
+    if(!test) {
+        // This might be null. Let's default to false.
+        test = false;
+    };
     var btn = '#checknow';
     if (test) {
       btn = '#testcheck';

--- a/tests/test_backend_github.py
+++ b/tests/test_backend_github.py
@@ -73,6 +73,7 @@ class GithubBackendtests(Modeltests):
         self.session.commit()
 
         # project homepage on GitHub but not project root
+        # should correctly match only needed segment
         project = model.Project(
             name='pkgdb2',
             homepage='https://github.com/fedora-infra/pkgdb2/issues',

--- a/tests/test_backend_github.py
+++ b/tests/test_backend_github.py
@@ -52,6 +52,8 @@ class GithubBackendtests(Modeltests):
 
     def create_project(self):
         """ Create some basic projects to work with. """
+
+        # regular GitHub project homepage with version_url
         project = model.Project(
             name='fedocal',
             homepage='https://github.com/fedora-infra/fedocal',
@@ -61,18 +63,19 @@ class GithubBackendtests(Modeltests):
         self.session.add(project)
         self.session.commit()
 
+        # project homepage with trailing slash
         project = model.Project(
             name='foobar',
-            homepage='http://github.com/foo/bar',
-            version_url='foobar/bar',
+            homepage='http://github.com/foo/bar/',
             backend=BACKEND,
         )
         self.session.add(project)
         self.session.commit()
 
+        # project homepage on GitHub but not project root
         project = model.Project(
             name='pkgdb2',
-            homepage='https://github.com/fedora-infra/pkgdb2',
+            homepage='https://github.com/fedora-infra/pkgdb2/issues',
             backend=BACKEND,
         )
         self.session.add(project)


### PR DESCRIPTION
Bug:

 - GitHub upstream detection was imperfect (e.g URL needed to be in `https://`)
 - Broken fetch URL generation resulting from bug in code (see https://github.com/fedora-infra/anitya/blob/master/anitya/lib/backends/github.py#L45 -- returns only last letter from string, doesn't return string except last letter)

Patch:

 - Remove some redundant code
 - Use regex rather than fragile `startswith` and `endswith` detection mechanisms
 - Fix broken fetch URL generation