### PR TITLE
Edited keyboard shortcut triggered in project page search box

### DIFF
--- a/anitya/templates/project.html
+++ b/anitya/templates/project.html
@@ -251,11 +251,11 @@
     if (event.ctrlKey){
         return false;
     }
-    if (event.which == 69) { //e
+    if (event.which == 69 && !$("#searchbox").is(':focus')) { //e
       window.location.replace("{{ url_for('edit_project', project_id=project.id) }}");
     }
     {% if g.auth.logged_in and (not project.versions or is_admin) %}
-    if (event.which == 67) { //c
+    if (event.which == 67 && !$("#searchbox").is(':focus')) { //c
       checkrelease();
       return false;
     }


### PR DESCRIPTION
Fix for issue #229. Added search textbox focus condition in keyboard bind javascript code. It won't trigger shortcut if search box is focussed