### PR TITLE
Feature/maven central update

### DIFF
--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -36,7 +36,7 @@
               {{ render_field_in_row(form.regex) }}
             </tr>
             <tr id="default_regex_row">
-              <td><label>Default regex:</lable></td>
+              <td><label>Default regex:</label></td>
               <td id="regex_example_txt"></td>
             </tr>
             <tr id="examples_row">

--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -146,6 +146,10 @@
       + "differs from the name of the project. </p>" );
       $('#version_url_row').show();
     };
+    if (str == 'Maven Central'){
+      $("label[for='version_url']").text('Maven groupId:artifactId');
+      $('#version_url_row').show();
+    };
     if (str == 'custom'){
       $('#version_url_row').show();
       $('#insecure_row').show();


### PR DESCRIPTION
Enables using version_url field for inputting artifact coordinates instead of
abusing project name (which will still be possible for backwards compatibility).