### PR TITLE
Documentation: Strict usage of python2.x

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,11 @@ Notifications service).
 Hacking
 -------
 
+Anitya is built using `python2.x`. The following steps all are setup using
+virtualenv having `python2.x`.
+
+Note: The project will not work with `python3` (yet.)
+
 virtualenv
 ``````````
 


### PR DESCRIPTION
The project fails to setup with python3 and a virtualenv with
the same. It's much better to mention about the python version
for those willing to contribute to this project.

Fixes https://github.com/fedora-infra/anitya/issues/262