### PR TITLE
Port from using user's email to use user's email address

### DIFF
--- a/anitya/admin.py
+++ b/anitya/admin.py
@@ -32,7 +32,7 @@ def add_distro():
             distro=distro,
             topic='distro.add',
             message=dict(
-                agent=flask.g.auth.email,
+                agent=flask.g.auth.openid,
                 distro=distro.name,
             )
         )
@@ -76,7 +76,7 @@ def edit_distro(distro_name):
                 distro=distro,
                 topic='distro.edit',
                 message=dict(
-                    agent=flask.g.auth.email,
+                    agent=flask.g.auth.openid,
                     old=distro.name,
                     new=name,
                 )
@@ -119,7 +119,7 @@ def delete_distro(distro_name):
             distro=distro,
             topic='distro.remove',
             message=dict(
-                agent=flask.g.auth.email,
+                agent=flask.g.auth.openid,
                 distro=distro.name,
             )
         )
@@ -159,7 +159,7 @@ def delete_project(project_id):
                 project=project,
                 topic='project.remove',
                 message=dict(
-                    agent=flask.g.auth.email,
+                    agent=flask.g.auth.openid,
                     project=project.name,
                 )
             )
@@ -214,7 +214,7 @@ def delete_project_mapping(project_id, distro_name, pkg_name):
                 project=project,
                 topic='project.map.remove',
                 message=dict(
-                    agent=flask.g.auth.email,
+                    agent=flask.g.auth.openid,
                     project=project.name,
                     distro=distro.name,
                 )
@@ -269,7 +269,7 @@ def delete_project_version(project_id, version):
                 project=project,
                 topic='project.version.remove',
                 message=dict(
-                    agent=flask.g.auth.email,
+                    agent=flask.g.auth.openid,
                     project=project.name,
                     version=version,
                 )
@@ -302,7 +302,7 @@ def browse_logs():
     if is_admin():
         user = flask.request.args.get('user', None)
     else:
-        user = flask.g.auth.email
+        user = flask.g.auth.openid
 
     from_date = flask.request.args.get('from_date', None)
     project = flask.request.args.get('project', None)
@@ -483,7 +483,7 @@ def set_flag_state(flag_id, state):
                 SESSION,
                 flag=flag,
                 state=state,
-                user_mail=flask.g.auth.email,
+                user_id=flask.g.auth.openid,
             )
             flask.flash('Flag {0} set to {1}'.format(flag.id, state))
         except anitya.lib.exceptions.AnityaException as err:

--- a/anitya/lib/__init__.py
+++ b/anitya/lib/__init__.py
@@ -275,13 +275,13 @@ def map_project(
     return pkg
 
 
-def flag_project(session, project, reason, user_id):
+def flag_project(session, project, reason, user_email, user_id):
     """ Flag a project in the database.
 
     """
 
     flag = anitya.lib.model.ProjectFlag(
-        user=user_id,
+        user=user_email,
         project=project,
         reason=reason)
 

--- a/anitya/lib/__init__.py
+++ b/anitya/lib/__init__.py
@@ -76,7 +76,7 @@ def init(db_url, alembic_ini=None, debug=False, create=False):
 
 
 def create_project(
-        session, name, homepage, user_mail, backend='custom',
+        session, name, homepage, user_id, backend='custom',
         version_url=None, version_prefix=None, regex=None):
     """ Create the project in the database.
 
@@ -105,7 +105,7 @@ def create_project(
         project=project,
         topic='project.add',
         message=dict(
-            agent=user_mail,
+            agent=user_id,
             project=project.name,
         )
     )
@@ -115,7 +115,7 @@ def create_project(
 
 def edit_project(
         session, project, name, homepage, backend, version_url,
-        version_prefix, regex, insecure, user_mail):
+        version_prefix, regex, insecure, user_id):
     """ Edit a project in the database.
 
     """
@@ -160,7 +160,7 @@ def edit_project(
                 project=project,
                 topic='project.edit',
                 message=dict(
-                    agent=user_mail,
+                    agent=user_id,
                     project=project.name,
                     fields=changes.keys(),  # be backward compat
                     changes=changes,
@@ -177,7 +177,7 @@ def edit_project(
 
 
 def map_project(
-        session, project, package_name, distribution, user_mail,
+        session, project, package_name, distribution, user_id,
         old_package_name=None, old_distro_name=None):
     """ Map a project to a distribution.
 
@@ -194,7 +194,7 @@ def map_project(
             distro=distro_obj,
             topic='distro.add',
             message=dict(
-                agent=user_mail,
+                agent=user_id,
                 distro=distro_obj.name,
             )
         )
@@ -255,7 +255,7 @@ def map_project(
             'admin.' % (package_name, distribution))
 
     message = dict(
-        agent=user_mail,
+        agent=user_id,
         project=project.name,
         distro=distro_obj.name,
         new=package_name,
@@ -275,13 +275,13 @@ def map_project(
     return pkg
 
 
-def flag_project(session, project, reason, user_mail):
+def flag_project(session, project, reason, user_id):
     """ Flag a project in the database.
 
     """
 
     flag = anitya.lib.model.ProjectFlag(
-        user=user_mail,
+        user=user_id,
         project=project,
         reason=reason)
 
@@ -300,7 +300,7 @@ def flag_project(session, project, reason, user_mail):
         project=project,
         topic='project.flag',
         message=dict(
-            agent=user_mail,
+            agent=user_id,
             project=project.name,
             reason=reason,
             packages=[pkg.__json__() for pkg in project.packages],
@@ -310,7 +310,7 @@ def flag_project(session, project, reason, user_mail):
     return flag
 
 
-def set_flag_state(session, flag, state, user_mail):
+def set_flag_state(session, flag, state, user_id):
     """ Change the state of a ProjectFlag in the database.
 
     """
@@ -336,7 +336,7 @@ def set_flag_state(session, flag, state, user_mail):
         session,
         topic='project.flag.set',
         message=dict(
-            agent=user_mail,
+            agent=user_id,
             flag=flag.id,
             state=state,
         )

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -452,6 +452,7 @@ def flag_project(project_id):
                 SESSION,
                 project=project,
                 reason=form.reason.data,
+                user_email=flask.g.auth.email,
                 user_id=flask.g.auth.openid,
             )
             flask.flash('Project flagged for admin review')

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -354,7 +354,7 @@ def new_project():
                 version_url=form.version_url.data.strip() or None,
                 version_prefix=form.version_prefix.data.strip() or None,
                 regex=form.regex.data.strip() or None,
-                user_mail=flask.g.auth.email,
+                user_id=flask.g.auth.openid,
             )
             SESSION.commit()
 
@@ -365,7 +365,7 @@ def new_project():
                     project=project,
                     package_name=form.package_name.data,
                     distribution=form.distro.data,
-                    user_mail=flask.g.auth.email,
+                    user_id=flask.g.auth.openid,
                 )
                 SESSION.commit()
 
@@ -414,7 +414,7 @@ def edit_project(project_id):
                 version_prefix=form.version_prefix.data.strip(),
                 regex=form.regex.data.strip(),
                 insecure=form.insecure.data,
-                user_mail=flask.g.auth.email,
+                user_id=flask.g.auth.openid,
             )
             flask.flash('Project edited')
             flask.session['justedit'] = True
@@ -452,7 +452,7 @@ def flag_project(project_id):
                 SESSION,
                 project=project,
                 reason=form.reason.data,
-                user_mail=flask.g.auth.email,
+                user_id=flask.g.auth.openid,
             )
             flask.flash('Project flagged for admin review')
         except anitya.lib.exceptions.AnityaException as err:
@@ -492,7 +492,7 @@ def map_project(project_id):
                 project=project,
                 package_name=form.package_name.data.strip(),
                 distribution=form.distro.data.strip(),
-                user_mail=flask.g.auth.email,
+                user_id=flask.g.auth.openid,
             )
             SESSION.commit()
             flask.flash('Mapping added')
@@ -536,7 +536,7 @@ def edit_project_mapping(project_id, pkg_id):
                 project=project,
                 package_name=form.package_name.data,
                 distribution=form.distro.data,
-                user_mail=flask.g.auth.email,
+                user_id=flask.g.auth.openid,
                 old_package_name=package.package_name,
                 old_distro_name=package.distro,
             )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -197,7 +197,9 @@ def create_flagged_project(session):
         session,
         project,
         "This is a duplicate.",
-        "dgay@redhat.com")
+        "dgay@redhat.com",
+        "user_openid_id",
+    )
 
     session.add(flag)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -141,7 +141,7 @@ def create_project(session):
         homepage='http://www.geany.org/',
         version_url='http://www.geany.org/Download/Releases',
         regex='DEFAULT',
-        user_mail='noreply@fedoraproject.org',
+        user_id='noreply@fedoraproject.org',
     )
 
     anitya.lib.create_project(
@@ -150,14 +150,14 @@ def create_project(session):
         homepage='http://subsurface.hohndel.org/',
         version_url='http://subsurface.hohndel.org/downloads/',
         regex='DEFAULT',
-        user_mail='noreply@fedoraproject.org',
+        user_id='noreply@fedoraproject.org',
     )
 
     anitya.lib.create_project(
         session,
         name='R2spec',
         homepage='https://fedorahosted.org/r2spec/',
-        user_mail='noreply@fedoraproject.org',
+        user_id='noreply@fedoraproject.org',
     )
 
 
@@ -188,7 +188,7 @@ def create_flagged_project(session):
         homepage='http://www.geany.org/',
         version_url='http://www.geany.org/Download/Releases',
         regex='DEFAULT',
-        user_mail='noreply@fedoraproject.org',
+        user_id='noreply@fedoraproject.org',
     )
 
     session.add(project)

--- a/tests/test_anityalib.py
+++ b/tests/test_anityalib.py
@@ -53,7 +53,7 @@ class AnityaLibtests(Modeltests):
             homepage='http://www.geany.org/',
             version_url='http://www.geany.org/Download/Releases',
             regex='DEFAULT',
-            user_mail='noreply@fedoraproject.org',
+            user_id='noreply@fedoraproject.org',
         )
 
         project_objs = anitya.lib.model.Project.all(self.session)
@@ -69,7 +69,7 @@ class AnityaLibtests(Modeltests):
             homepage='http://www.geany.org/',
             version_url='http://www.geany.org/Download/Releases',
             regex='DEFAULT',
-            user_mail='noreply@fedoraproject.org',
+            user_id='noreply@fedoraproject.org',
         )
 
         project_objs = anitya.lib.model.Project.all(self.session)
@@ -99,7 +99,7 @@ class AnityaLibtests(Modeltests):
             version_prefix=None,
             regex=None,
             insecure=False,
-            user_mail='noreply@fedoraproject.org')
+            user_id='noreply@fedoraproject.org')
 
         project_objs = anitya.lib.model.Project.all(self.session)
         self.assertEqual(len(project_objs), 3)
@@ -120,7 +120,7 @@ class AnityaLibtests(Modeltests):
             version_prefix=None,
             regex=project_objs[2].regex,
             insecure=False,
-            user_mail='noreply@fedoraproject.org',
+            user_id='noreply@fedoraproject.org',
         )
 
     def test_map_project(self):
@@ -138,7 +138,7 @@ class AnityaLibtests(Modeltests):
             project=project_obj,
             package_name='geany',
             distribution='CentOS',
-            user_mail='noreply@fedoraproject.org',
+            user_id='noreply@fedoraproject.org',
             old_package_name=None,
         )
         self.session.commit()
@@ -155,7 +155,7 @@ class AnityaLibtests(Modeltests):
             project=project_obj,
             package_name='geany2',
             distribution='CentOS',
-            user_mail='noreply@fedoraproject.org',
+            user_id='noreply@fedoraproject.org',
             old_package_name=None,
         )
         self.session.commit()
@@ -174,7 +174,7 @@ class AnityaLibtests(Modeltests):
             project=project_obj,
             package_name='geany3',
             distribution='Fedora',
-            user_mail='noreply@fedoraproject.org',
+            user_id='noreply@fedoraproject.org',
             old_package_name='geany',
             old_distro_name='CentOS',
         )
@@ -201,7 +201,7 @@ class AnityaLibtests(Modeltests):
             project=project_obj,
             package_name='geany2',
             distribution='CentOS',
-            user_mail='noreply@fedoraproject.org',
+            user_id='noreply@fedoraproject.org',
         )
 
 


### PR DESCRIPTION
Fixes https://github.com/fedora-infra/anitya/issues/205

(We will need a change to fedmsg_meta to convert back from email Fedora users using the Fedora openid identifiers)