### PR TITLE
Fix timezone-sensitive tests.

### DIFF
--- a/tests/test_flask_admin.py
+++ b/tests/test_flask_admin.py
@@ -416,13 +416,13 @@ class FlaskAdminTest(Modeltests):
             self.assertTrue('<h1>Logs</h1>' in output.data)
             self.assertTrue('added the distro named: Debian' in output.data)
 
-            output = c.get('/logs?from_date=%s' % datetime.date.today())
+            output = c.get('/logs?from_date=%s' % datetime.datetime.utcnow().date())
             self.assertEqual(output.status_code, 200)
             self.assertTrue('<h1>Logs</h1>' in output.data)
             self.assertTrue('added the distro named: Debian' in output.data)
 
             # the Debian log shouldn't show up if the "from date" is tomorrow
-            tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+            tomorrow = datetime.datetime.utcnow().date() + datetime.timedelta(days=1)
             output = c.get('/logs?from_date=%s' % tomorrow)
             self.assertEqual(output.status_code, 200)
             self.assertTrue('<h1>Logs</h1>' in output.data)
@@ -467,19 +467,19 @@ class FlaskAdminTest(Modeltests):
             self.assertTrue('<h1>Flags</h1>' in output.data)
             self.assertTrue('geany' in output.data)
 
-            output = c.get('/flags?from_date=%s' % datetime.date.today())
+            output = c.get('/flags?from_date=%s' % datetime.datetime.utcnow().date())
             self.assertEqual(output.status_code, 200)
             self.assertTrue('<h1>Flags</h1>' in output.data)
             self.assertTrue('geany' in output.data)
 
             # geany shouldn't show up if the "from date" is tomorrow
-            tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+            tomorrow = datetime.datetime.utcnow().date() + datetime.timedelta(days=1)
             output = c.get('/flags?from_date=%s' % tomorrow)
             self.assertEqual(output.status_code, 200)
             self.assertTrue('<h1>Flags</h1>' in output.data)
             self.assertFalse('geany' in output.data)
 
-            output = c.get('/flags?from_date=%s&project=geany' % datetime.date.today())
+            output = c.get('/flags?from_date=%s&project=geany' % datetime.datetime.utcnow().date())
             self.assertEqual(output.status_code, 200)
             self.assertTrue('<h1>Flags</h1>' in output.data)
             self.assertTrue('geany' in output.data)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -79,7 +79,7 @@ class Modeltests(Modeltests):
         logs = model.Log.search(self.session, count=True)
         self.assertEqual(logs, 3)
 
-        from_date = datetime.date.today() - datetime.timedelta(days=1)
+        from_date = datetime.datetime.utcnow().date() - datetime.timedelta(days=1)
         logs = model.Log.search(
             self.session, from_date=from_date, offset=1, limit=1)
         self.assertEqual(len(logs), 1)


### PR DESCRIPTION
These fail for me during certain times of the day when the date in my locale
and the date in UTC do not match.  This switches the tests to be consistently
in UTC, removing that sensitivity.