### PR TITLE
Add a new check-feed mode for the backend.

### DIFF
--- a/anitya/lib/backends/__init__.py
+++ b/anitya/lib/backends/__init__.py
@@ -25,6 +25,11 @@ REGEX = b'%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?i)(?:[-_]'\
     '(?:minsrc|src|source|asc))?\.(?:tar|t[bglx]z|tbz2|zip)'
 
 
+# Use a common http session, so we don't have to go re-establishing https
+# connections over and over and over again.
+http_session = requests.session()
+
+
 def upstream_cmp(v1, v2):
     """ Compare two upstream versions
 
@@ -263,7 +268,7 @@ class BaseBackend(object):
                 'From': from_email,
             }
 
-            return requests.get(url, headers=headers, verify=not insecure)
+            return http_session.get(url, headers=headers, verify=not insecure)
 
 
 def get_versions_by_regex(url, regex, project, insecure=False):

--- a/anitya/lib/backends/__init__.py
+++ b/anitya/lib/backends/__init__.py
@@ -215,6 +215,26 @@ class BaseBackend(object):
         pass
 
     @classmethod
+    def check_feed(self):
+        ''' Method called to retrieve the latest uploads to a given backend,
+        via, for example, RSS or an API.
+
+        Not all backends may support this.  It can be used to look for updates
+        much more quickly than scanning all known projects.
+
+        :return: a list of 4-tuples, containing the project name, homepage, the
+            backend, and the version.
+        :return type: list
+        :raise AnityaPluginException: a
+            :class:`anitya.lib.exceptions.AnityaPluginException` exception
+            when the version cannot be retrieved correctly
+        :raise NotImplementedError:
+            :class:`NotImplementedError` exception when the backend does not
+            support batch updates.
+        '''
+        raise NotImplementedError()
+
+    @classmethod
     def get_ordered_versions(self, project):
         ''' Method called to retrieve all the versions (that can be found)
         of the projects provided, ordered from the oldest to the newest.

--- a/anitya/lib/backends/cpan.py
+++ b/anitya/lib/backends/cpan.py
@@ -1,15 +1,18 @@
 # -*- coding: utf-8 -*-
 
 """
- (c) 2014 - Copyright Red Hat Inc
+ (c) 2014-2016 - Copyright Red Hat Inc
 
  Authors:
    Pierre-Yves Chibon <pingou@pingoured.fr>
+   Ralph Bean <rbean@redhat.com>
 
 """
 
+import xml2dict
 
 from anitya.lib.backends import BaseBackend, get_versions_by_regex, REGEX
+from anitya.lib.exceptions import AnityaPluginException
 
 
 class CpanBackend(BaseBackend):
@@ -62,3 +65,31 @@ class CpanBackend(BaseBackend):
         regex = REGEX % {'name': project.name}
 
         return get_versions_by_regex(url, regex, project)
+
+    @classmethod
+    def check_feed(cls):
+        ''' Return a generator over the latest uploads to CPAN
+
+        by querying an RSS feed.
+        '''
+
+        url = 'http://search.cpan.org/uploads.rdf'
+
+        try:
+            response = cls.call_url(url)
+        except Exception:  # pragma: no cover
+            raise AnityaPluginException('Could not contact %s' % url)
+
+        try:
+            parser = xml2dict.XML2Dict()
+            data = parser.fromstring(response.text)
+        except Exception:  # pragma: no cover
+            raise AnityaPluginException('No XML returned by %s' % url)
+
+        items = data['RDF']['item']
+        for entry in items:
+            title = entry['title']['value']
+            name, version = title.rsplit('-', 1)
+            #homepage = entry['link']['value'].rsplit('-', 1)[0] + '/'
+            homepage = 'http://search.cpan.org/dist/%s/' % name
+            yield name, homepage, cls.name, version

--- a/anitya/lib/backends/hackage.py
+++ b/anitya/lib/backends/hackage.py
@@ -13,7 +13,7 @@ from anitya.lib.backends import BaseBackend, get_versions_by_regex, REGEX
 
 
 class HackageBackend(BaseBackend):
-    ''' The custom class for projects hosted on Google code.
+    ''' The custom class for projects hosted on hackage.
 
     This backend allows to specify a version_url and a regex that will
     be used to retrieve the version information.
@@ -62,3 +62,12 @@ class HackageBackend(BaseBackend):
         regex = REGEX % {'name': project.name}
 
         return get_versions_by_regex(url, regex, project)
+
+    @classmethod
+    def check_feed(cls):
+        ## See http://hackage.haskell.org/api#recentPackages
+        ## It should be possible to query this, but I can't figure out how to
+        ## get it to give me non-html.
+        # url = 'http://hackage.haskell.org/packages/recent/revisions'
+        raise NotImplementedError()
+

--- a/anitya/lib/backends/pear.py
+++ b/anitya/lib/backends/pear.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 
 """
- (c) 2014 - Copyright Red Hat Inc
+ (c) 2014-2016 - Copyright Red Hat Inc
 
  Authors:
    Pierre-Yves Chibon <pingou@pingoured.fr>
+   Ralph Bean <rbean@redhat.com>
 
 """
 
+import xml2dict
 
-from anitya.lib.backends import BaseBackend, get_versions_by_regex, REGEX
+from anitya.lib.backends import BaseBackend
 from anitya.lib.exceptions import AnityaPluginException
 
 
@@ -92,3 +94,30 @@ class PearBackend(BaseBackend):
                 'No versions found for %s' % project.name.lower())
 
         return versions
+
+    @classmethod
+    def check_feed(cls):
+        ''' Return a generator over the latest 10 uploads to PEAR
+
+        by querying an RSS feed.
+        '''
+
+        url = 'https://pear.php.net/feeds/latest.rss'
+
+        try:
+            response = cls.call_url(url)
+        except Exception:  # pragma: no cover
+            raise AnityaPluginException('Could not contact %s' % url)
+
+        try:
+            parser = xml2dict.XML2Dict()
+            data = parser.fromstring(response.text)
+        except Exception:  # pragma: no cover
+            raise AnityaPluginException('No XML returned by %s' % url)
+
+        items = data['RDF']['item']
+        for entry in items:
+            title = entry['title']['value']
+            name, version = title.rsplit(None, 1)
+            homepage = 'http://pear.php.net/package/%s' % name
+            yield name, homepage, cls.name, version

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ sqlalchemy
 # https://github.com/ironfroggy/straight.plugin/issues/17#issuecomment-41466275
 straight.plugin==1.4.0-post-1
 wtforms
-
+xml2dict

--- a/tests/test_backend_cpan.py
+++ b/tests/test_backend_cpan.py
@@ -106,6 +106,21 @@ class CpanBackendtests(Modeltests):
             project
         )
 
+    def test_cpan_check_feed(self):
+        """ Test the check_feed method of the cpan backend. """
+        generator = backend.CpanBackend.check_feed()
+        items = list(generator)
+
+        self.assertEqual(items[0], (
+            'Dist-Zilla-PluginBundle-Author-Plicease',
+            'http://search.cpan.org/dist/Dist-Zilla-PluginBundle-Author-Plicease/',
+            'CPAN (perl)', '2.06'))
+        self.assertEqual(items[1], (
+            'Dist-Zilla-Plugin-Author-Plicease',
+            'http://search.cpan.org/dist/Dist-Zilla-Plugin-Author-Plicease/',
+            'CPAN (perl)', '2.06'))
+        # etc...
+
 
 if __name__ == '__main__':
     SUITE = unittest.TestLoader().loadTestsFromTestCase(CpanBackendtests)

--- a/tests/test_backend_npmjs.py
+++ b/tests/test_backend_npmjs.py
@@ -148,6 +148,19 @@ class NpmjsBackendtests(Modeltests):
         obs = backend.NpmjsBackend.get_ordered_versions(project)
         self.assertEqual(obs, exp)
 
+    def test_npmjs_check_feed(self):
+        """ Test the check_feed method of the npmjs backend. """
+        generator = backend.NpmjsBackend.check_feed()
+        items = list(generator)
+
+        self.assertEqual(items[0], (
+            '0-_-0', 'http://npmjs.org/package/0-_-0', 'npmjs', '1.0.0'))
+        self.assertEqual(items[1], (
+            '111-react-simpleform',
+            'http://npmjs.org/package/111-react-simpleform',
+            'npmjs', '1.2.0'))
+        # etc...
+
 
 if __name__ == '__main__':
     SUITE = unittest.TestLoader().loadTestsFromTestCase(NpmjsBackendtests)

--- a/tests/test_backend_pear.py
+++ b/tests/test_backend_pear.py
@@ -109,6 +109,19 @@ class PearBackendtests(Modeltests):
             project
         )
 
+    def test_pear_check_feed(self):
+        """ Test the check_feed method of the pear backend. """
+        generator = backend.PearBackend.check_feed()
+        items = list(generator)
+
+        self.assertEqual(items[0], (
+            'File_Therion', 'http://pear.php.net/package/File_Therion',
+            'PEAR', '0.1.0'))
+        self.assertEqual(items[1], (
+            'Net_URL2', 'http://pear.php.net/package/Net_URL2',
+            'PEAR', '2.1.2'))
+        # etc...
+
 
 if __name__ == '__main__':
     SUITE = unittest.TestLoader().loadTestsFromTestCase(PearBackendtests)

--- a/tests/test_backend_pecl.py
+++ b/tests/test_backend_pecl.py
@@ -106,6 +106,18 @@ class PeclBackendtests(Modeltests):
             project
         )
 
+    def test_pecl_check_feed(self):
+        """ Test the check_feed method of the pecl backend. """
+        generator = backend.PeclBackend.check_feed()
+        items = list(generator)
+
+        self.assertEqual(items[0], (
+            'rrd', 'http://pecl.php.net/package/rrd', 'PECL', '2.0.1'))
+        self.assertEqual(items[1], (
+            'libsodium', 'http://pecl.php.net/package/libsodium',
+            'PECL', '1.0.6'))
+        # etc...
+
 
 if __name__ == '__main__':
     SUITE = unittest.TestLoader().loadTestsFromTestCase(PeclBackendtests)

--- a/tests/test_backend_pypi.py
+++ b/tests/test_backend_pypi.py
@@ -133,6 +133,19 @@ class PypiBackendtests(Modeltests):
         obs = backend.PypiBackend.get_ordered_versions(project)
         self.assertEqual(obs, exp)
 
+    def test_pypi_check_feed(self):
+        """ Test the check_feed method of the pypi backend. """
+        generator = backend.PypiBackend.check_feed()
+        items = list(generator)
+
+        self.assertEqual(items[0], (
+            'mkbrutus', 'https://pypi.python.org/pypi/mkbrutus',
+            'PyPI', '1.0.2a1'))
+        self.assertEqual(items[1], (
+            'ansible-lint', 'https://pypi.python.org/pypi/ansible-lint',
+            'PyPI', '3.0.0rc6'))
+        # etc...
+
 
 if __name__ == '__main__':
     SUITE = unittest.TestLoader().loadTestsFromTestCase(PypiBackendtests)

--- a/tests/test_backend_rubygems.py
+++ b/tests/test_backend_rubygems.py
@@ -102,6 +102,19 @@ class RubygemsBackendtests(Modeltests):
             project
         )
 
+    def test_rubygems_check_feed(self):
+        """ Test the check_feed method of the rubygems backend. """
+        generator = backend.RubygemsBackend.check_feed()
+        items = list(generator)
+
+        self.assertEqual(items[0], (
+            'culqi', 'http://rubygems.org/gems/culqi',
+            'Rubygems', '1.1.4'))
+        self.assertEqual(items[1], (
+            'rspec-instafail', 'http://rubygems.org/gems/rspec-instafail',
+            'Rubygems', '0.5.0'))
+        # etc...
+
 
 if __name__ == '__main__':
     SUITE = unittest.TestLoader().loadTestsFromTestCase(RubygemsBackendtests)


### PR DESCRIPTION
This is a rewrite of #239.

- It adds a new check_feed method to all of the backends that I could figure out.
- It adds tests for those.
- It adds a new --check-feed option to the cronjob, which uses those methods instead of the regular approach.

Without this PR, we currently run the cronjob twice a day (once every 12 hours)
which means that some new upstream releases we don't find out about for a "very
long time" (~12 hours).  We do that because our cronjob checks for a new
upstream release for *every* project we know about.  That takes a very long
time to run.

This new mode for the cronjob checks only for projects that are listed in the
RSS feeds and APIs of public indexes like pypi, rubygems, and cpan, etc..
It runs very quickly in comparison.  I bet we could run it as a cronjob once
every 5 minutes without much worry (we should wrap it in a lock script, though,
just to make sure they don't pile up).  I'd like to get as close to realtime as
possible.

In addition to scanning for new upstream releases, if the cronjob encounters a
*new* package in the RSS feed or API, then it also adds that to anitya's
database of projects (so that will grow over time, automatically now).