### PR TITLE
Issue #238 - Changed the __init__.py file to get version prefix correctly 

### DIFF
--- a/anitya/__init__.py
+++ b/anitya/__init__.py
@@ -56,7 +56,7 @@ def check_release(project, session, test=False):
     try:
         up_version = backend.get_version(project)
         if project.version_prefix:
-            up_version = up_version.replace(project.version_prefix, '')
+            up_version = up_version.replace(project.version_prefix, '', 1)
     except anitya.lib.exceptions.AnityaPluginException as err:
         LOG.exception("AnityaError catched:")
         project.logs = err.message


### PR DESCRIPTION
As mentioned in the issue, for example the `v2.0.0-develop.1` was turned into `2.0.0-deelop.1`. The fix removes just the first appearance of the `version_prefix`.