### PR TITLE
Adds redhat-rpm-config as a dependency in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora
 # cffi>=1.1.0->cryptography->fedmsg->-r
-RUN dnf install -y gcc python-devel libffi-devel openssl-devel git gcc-c++
+RUN dnf install -y gcc python-devel libffi-devel openssl-devel git gcc-c++ redhat-rpm-config
 
 RUN git clone https://github.com/fedora-infra/anitya.git /src
 WORKDIR /src


### PR DESCRIPTION
Fixes this error when running docker build:
```
Collecting cffi>=1.4.1 (from cryptography->fedmsg->-r requirements.txt (line 5))
  Downloading cffi-1.7.0.tar.gz (400kB)
    Complete output from command python setup.py egg_info:
    gcc: error: /usr/lib/rpm/redhat/redhat-hardened-cc1: No such file or directory
    gcc: error: /usr/lib/rpm/redhat/redhat-hardened-cc1: No such file or directory
    
        No working compiler found, or bogus compiler options
        passed to the compiler from Python's distutils module.
        See the error messages above.
        (If they are about -mno-fused-madd and you are on OS/X 10.8,
        see http://stackoverflow.com/questions/22313407/ .)
    
    ----------------------------------------
```

I'm also wondering why the Dockerfile is running a git clone instead of copying the contents in the current directory? This keeps the developer from being able to test their local changes in Docker.