### PR TITLE
Fixes/Cleans up the Docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM fedora
 # cffi>=1.1.0->cryptography->fedmsg->-r
-RUN dnf install -y gcc python-devel libffi-devel openssl-devel git gcc-c++ redhat-rpm-config
+RUN dnf install -y gcc python-devel libffi-devel openssl-devel gcc-c++ redhat-rpm-config && \
+    dnf autoremove -y && \
+    dnf clean all -y
 
-RUN git clone https://github.com/fedora-infra/anitya.git /src
+COPY ./ /src
 WORKDIR /src
 
-# in Fedora we have ancient cffi atm
-# RUN dnf install -y python-cffi
 RUN pip install --user -r requirements.txt
 RUN python createdb.py
 EXPOSE 5000
-CMD ./runserver.py
+ENTRYPOINT python runserver.py --host '0.0.0.0'
+

--- a/README.rst
+++ b/README.rst
@@ -63,20 +63,14 @@ running::
 Open your browser and visit http://localhost:5000 to check it out.
 
 
-docker
+Docker
 ``````
 
-You can use dockerfile provided in root of this repository. Build it::
+To build the Docker image::
 
     $ cd anitya/
     $ docker build --tag=anitya .
 
-And run::
+To run the container::
 
-    $ docker run --net=host anitya
-
-``--net=host`` will use network stack from your host system. Application will
-be then available on localhost at http://localhost:5000.
-
-If you inspect the dockerfile you can see that installation method is almost
-identical to the described in section virtualenv_.
+    $ docker run -d -p 5000:5000 anitya

--- a/runserver.py
+++ b/runserver.py
@@ -50,5 +50,5 @@ if args.config:
 
 
 from anitya.app import APP
+APP.debug = True
 APP.run(port=int(args.port), host=args.host)
-

--- a/runserver.py
+++ b/runserver.py
@@ -27,6 +27,10 @@ parser.add_argument(
 parser.add_argument(
     '--port', '-p', default=5000,
     help='Port for the flask application.')
+parser.add_argument(
+    '--host', default='127.0.0.1',
+    help='IP address for the flask application to bind to.'
+)
 
 args = parser.parse_args()
 
@@ -46,5 +50,5 @@ if args.config:
 
 
 from anitya.app import APP
-APP.debug = True
-APP.run(port=int(args.port))
+APP.run(port=int(args.port), host=args.host)
+


### PR DESCRIPTION
This PR does the following:
* Fixes the Docker file so that it can be run on a Docker host and accessible externally
* Adds a host option to runserver.py (required for the port forwarding to work in Docker)
* Turns off app debug by default as this should not be run this way with Docker
* Copies the source code from the working directory instead of `git clone` in order to allow the developer to test local changes in Docker before committing code

Eventually, this should run behind Apache + mod_wsgi, but this at least gets Docker in a functioning state.