### PR TITLE
Add upstream ecosystems to model

### DIFF
--- a/alembic/README.md
+++ b/alembic/README.md
@@ -1,0 +1,14 @@
+Generating new revisions
+========================
+
+For a branch based on `origin/master` that includes schema changes:
+
+    $ rm /var/tmp/anitya-dev.sqlite
+    $ git checkout origin/master
+    $ python createdb.py
+    $ git checkout <my working branch>
+    $ alembic stamp head
+    $ alembic revision --autogenerate -m "<Title for schema update>"`
+
+Table creation is handled by `createdb.py`, so edit the generated migration
+to remove the table creation commands.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,4 +1,6 @@
 from __future__ import with_statement
+import sys
+from os.path import dirname
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 from logging.config import fileConfig
@@ -13,9 +15,9 @@ fileConfig(config.config_file_name)
 
 # add your model's MetaData object here
 # for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
-target_metadata = None
+sys.path.append(dirname(dirname(__file__)))
+from anitya.lib.model import BASE
+target_metadata = BASE.metadata
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:

--- a/alembic/versions/921c612ba0da_model_upstream_ecosystems.py
+++ b/alembic/versions/921c612ba0da_model_upstream_ecosystems.py
@@ -1,0 +1,26 @@
+"""Model upstream ecosystems
+
+Revision ID: 921c612ba0da
+Revises: 2925648d8cc3
+Create Date: 2016-08-09 18:44:53.119461
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '921c612ba0da'
+down_revision = '2925648d8cc3'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('projects', sa.Column('ecosystem_name', sa.String(length=200), nullable=True))
+    op.create_unique_constraint('UNIQ_PROJECT_NAME_PER_ECOSYSTEM', 'projects', ['name', 'ecosystem_name'])
+    op.create_foreign_key('FK_ECOSYSTEM_FOR_PROJECT', 'projects', 'ecosystems', ['ecosystem_name'], ['name'], onupdate='cascade', ondelete='set null')
+
+
+def downgrade():
+    op.drop_constraint('FK_ECOSYSTEM_FOR_PROJECT', 'projects', type_='foreignkey')
+    op.drop_constraint('UNIQ_PROJECT_NAME_PER_ECOSYSTEM', 'projects', type_='unique')
+    op.drop_column('projects', 'ecosystem_name')

--- a/anitya/api.py
+++ b/anitya/api.py
@@ -550,3 +550,66 @@ def api_get_project_distro(distro, package_name):
     jsonout = flask.jsonify(output)
     jsonout.status_code = httpcode
     return jsonout
+
+@APP.route('/api/by_ecosystem/<ecosystem>/<project_name>/', methods=['GET'])
+@APP.route('/api/by_ecosystem/<ecosystem>/<project_name>', methods=['GET'])
+def api_get_project_ecosystem(ecosystem, project_name):
+    '''
+    Retrieve a project from a given ecosystem
+    -------------------------------
+    Retrieves a project in an ecosystem via the name of the ecosystem
+    and the name of the project as registered with Anitya.
+
+    ::
+
+        /api/by_ecosystem/<ecosystem>/<project_name>
+
+    Accepts GET queries only.
+
+    :arg ecosystem: the name of the ecosystem (case insensitive).
+    :arg project_name: the name of the project in Anitya.
+
+    Sample response:
+
+    ::
+
+      {
+        "backend": "pypi",
+        "created_on": 1409917222.0,
+        "homepage": "https://pypi.python.org/pypi/six",
+        "id": 2,
+        "name": "six",
+        "packages": [
+          {
+            "distro": "Fedora",
+            "package_name": "python-six"
+          }
+        ],
+        "regex": null,
+        "updated_on": 1414400794.0,
+        "version": "1.10.0",
+        "version_url": null,
+        "versions": [
+          "1.10.0"
+        ]
+      }
+
+    '''
+
+    project = anitya.lib.model.Project.by_name_and_ecosystem(
+        SESSION, project_name, ecosystem)
+
+    if not project:
+        output = {
+            'output': 'notok',
+            'error': 'No project "%s" found in ecosystem "%s"' % (
+                project_name, ecosystem)}
+        httpcode = 404
+
+    else:
+        output = project.__json__(detailed=True)
+        httpcode = 200
+
+    jsonout = flask.jsonify(output)
+    jsonout.status_code = httpcode
+    return jsonout

--- a/anitya/lib/__init__.py
+++ b/anitya/lib/__init__.py
@@ -81,10 +81,15 @@ def create_project(
     """ Create the project in the database.
 
     """
+    # Set the ecosystem if there's one associated with the given backend
+    backend_ref = anitya.lib.model.Backend.by_name(session, name=backend)
+    ecosystem_ref = backend_ref.default_ecosystem
+
     project = anitya.lib.model.Project(
         name=name,
         homepage=homepage,
         backend=backend,
+        ecosystem=ecosystem_ref,
         version_url=version_url,
         regex=regex,
         version_prefix=version_prefix,

--- a/anitya/lib/ecosystems/__init__.py
+++ b/anitya/lib/ecosystems/__init__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+"""
+ (c) 2016 - Copyright Red Hat Inc
+
+ Authors:
+   Nick Coghlan <ncoghlan@redhat.com>
+
+"""
+
+
+class BaseEcosystem(object):
+    ''' The base class that all the different ecosystems should extend. '''
+
+    name = None
+    default_backend = None

--- a/anitya/lib/ecosystems/maven.py
+++ b/anitya/lib/ecosystems/maven.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+"""
+ (c) 2016 - Copyright Red Hat Inc
+
+ Authors:
+   Nick Coghlan <ncoghlan@redhat.com>
+
+"""
+from . import BaseEcosystem
+
+class MavenEcosystem(BaseEcosystem):
+    ''' The Maven ecosystem class'''
+
+    name = "maven"
+    default_backend = "Maven Central"

--- a/anitya/lib/ecosystems/npm.py
+++ b/anitya/lib/ecosystems/npm.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+"""
+ (c) 2016 - Copyright Red Hat Inc
+
+ Authors:
+   Nick Coghlan <ncoghlan@redhat.com>
+
+"""
+from . import BaseEcosystem
+
+class NpmEcosystem(BaseEcosystem):
+    ''' The npm ecosystem class'''
+
+    name = "npm"
+    default_backend = "npmjs"

--- a/anitya/lib/ecosystems/pypi.py
+++ b/anitya/lib/ecosystems/pypi.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+"""
+ (c) 2016 - Copyright Red Hat Inc
+
+ Authors:
+   Nick Coghlan <ncoghlan@redhat.com>
+
+"""
+from . import BaseEcosystem
+
+class PypiEcosystem(BaseEcosystem):
+    ''' The PyPI ecosystem class'''
+
+    name = "pypi"
+    default_backend = "PyPI"

--- a/anitya/lib/ecosystems/rubygems.py
+++ b/anitya/lib/ecosystems/rubygems.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+"""
+ (c) 2016 - Copyright Red Hat Inc
+
+ Authors:
+   Nick Coghlan <ncoghlan@redhat.com>
+
+"""
+from . import BaseEcosystem
+
+class RubygemsEcosystem(BaseEcosystem):
+    ''' The rubygems ecosystem class'''
+
+    name = "rubygems"
+    default_backend = "Rubygems"

--- a/anitya/lib/model.py
+++ b/anitya/lib/model.py
@@ -175,7 +175,10 @@ class Ecosystem(BASE):
 
     @classmethod
     def by_name(cls, session, name):
-        return session.query(cls).filter_by(name=name).first()
+        try:
+            return session.query(cls).filter_by(name=name).one()
+        except NoResultFound:
+            return None
 
     get = by_name
 
@@ -434,7 +437,6 @@ class Project(BASE):
                     .filter(Ecosystem.name==ecosystem).one())
         except NoResultFound:
             return None
-
 
     @classmethod
     def all(cls, session, page=None, count=False):

--- a/anitya/lib/model.py
+++ b/anitya/lib/model.py
@@ -19,6 +19,8 @@ import time
 
 import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
+from sqlalchemy.orm.exc import NoResultFound
 
 import anitya
 
@@ -136,6 +138,35 @@ class Backend(BASE):
     __tablename__ = 'backends'
 
     name = sa.Column(sa.String(200), primary_key=True)
+    default_ecosystem = relationship("Ecosystem", uselist=False,
+                                     back_populates="default_backend")
+
+    @classmethod
+    def all(cls, session):
+        query = session.query(cls).order_by(cls.name)
+        return query.all()
+
+    @classmethod
+    def by_name(cls, session, name):
+        return session.query(cls).filter_by(name=name).first()
+
+    get = by_name
+
+
+class Ecosystem(BASE):
+    __tablename__ = 'ecosystems'
+
+    name = sa.Column(sa.String(200), primary_key=True)
+    default_backend_name = sa.Column(
+        sa.String(200),
+        sa.ForeignKey("backends.name",
+            ondelete="cascade",
+            onupdate="cascade"),
+        unique=True
+    )
+    default_backend = relationship("Backend",
+                                   back_populates="default_ecosystem")
+    projects = relationship("Project", back_populates="ecosystem")
 
     @classmethod
     def all(cls, session):
@@ -292,6 +323,7 @@ class Project(BASE):
     name = sa.Column(sa.String(200), nullable=False, index=True)
     homepage = sa.Column(sa.String(200), nullable=False)
 
+    # TODO: Define ORM forward/backward references for backend as for ecosystem
     backend = sa.Column(
         sa.String(200),
         sa.ForeignKey(
@@ -300,6 +332,14 @@ class Project(BASE):
             onupdate="cascade"),
         default='custom',
     )
+    ecosystem_name = sa.Column(
+        sa.String(200),
+        sa.ForeignKey("ecosystems.name",
+            ondelete="set null",
+            onupdate="cascade"),
+        nullable=True
+    )
+    ecosystem = relationship("Ecosystem", back_populates="projects")
     version_url = sa.Column(sa.String(200), nullable=True)
     regex = sa.Column(sa.String(200), nullable=True)
     version_prefix = sa.Column(sa.String(200), nullable=True)
@@ -316,6 +356,7 @@ class Project(BASE):
 
     __table_args__ = (
         sa.UniqueConstraint('name', 'homepage'),
+        sa.UniqueConstraint('name', 'ecosystem_name'),
     )
 
     @property
@@ -383,6 +424,17 @@ class Project(BASE):
         return session.query(cls)\
             .filter_by(name=name)\
             .filter_by(homepage=homepage).first()
+
+    @classmethod
+    def by_name_and_ecosystem(cls, session, name, ecosystem):
+        try:
+            return (session.query(cls)
+                    .filter_by(name=name)
+                    .join(Project.ecosystem)
+                    .filter(Ecosystem.name==ecosystem).one())
+        except NoResultFound:
+            return None
+
 
     @classmethod
     def all(cls, session, page=None, count=False):

--- a/anitya/lib/model.py
+++ b/anitya/lib/model.py
@@ -339,7 +339,8 @@ class Project(BASE):
         sa.String(200),
         sa.ForeignKey("ecosystems.name",
             ondelete="set null",
-            onupdate="cascade"),
+            onupdate="cascade",
+            name="FK_ECOSYSTEM_FOR_PROJECT"),
         nullable=True
     )
     ecosystem = relationship("Ecosystem", back_populates="projects")
@@ -359,7 +360,8 @@ class Project(BASE):
 
     __table_args__ = (
         sa.UniqueConstraint('name', 'homepage'),
-        sa.UniqueConstraint('name', 'ecosystem_name'),
+        sa.UniqueConstraint('name', 'ecosystem_name',
+                            name="UNIQ_PROJECT_NAME_PER_ECOSYSTEM"),
     )
 
     @property

--- a/anitya/lib/plugins.py
+++ b/anitya/lib/plugins.py
@@ -9,47 +9,96 @@
 Module handling the load/call of the plugins of anitya
 """
 
+import logging
+
 from sqlalchemy.exc import SQLAlchemyError
 
 from straight.plugin import load
 
 import anitya.lib.model as model
 from anitya.lib.backends import BaseBackend
+from anitya.lib.ecosystems import BaseEcosystem
 
+log = logging.getLogger(__name__)
 
-def load_plugins(session):
-    ''' Load all the plugins and insert them in the database if they are
-    not already present. '''
+class _PluginManager(object):
+    """Manage a particular set of Anitya plugins"""
+    def __init__(self, namespace, base_class):
+        self._namespace = namespace
+        self._base_class = base_class
+
+    def get_plugins(self):
+        ''' Return the list of plugins.'''
+        return load(self._namespace, subclasses=self._base_class)
+
+    def get_plugin_names(self):
+        ''' Return the list of plugin names. '''
+        plugins = self.get_plugins()
+        output = [plugin.name for plugin in plugins]
+        return output
+
+    def get_plugin(self, plugin_name):
+        ''' Return the plugin corresponding to the given plugin name. '''
+        plugins = self.get_plugins()
+        for plugin in plugins:
+            if plugin.name.lower() == plugin_name.lower():
+                return plugin
+
+BACKEND_PLUGINS = _PluginManager('anitya.lib.backends', BaseBackend)
+ECOSYSTEM_PLUGINS = _PluginManager('anitya.lib.ecosystems', BaseEcosystem)
+
+def _load_backend_plugins(session):
+    """Load any new backend plugins into the DB"""
     backends = [bcke.name for bcke in model.Backend.all(session)]
-
-    plugins = get_plugins()
-    plg_names = [plugin.name for plugin in plugins]
-    for backend in set(backends).symmetric_difference(set(plg_names)):
+    plugins = list(BACKEND_PLUGINS.get_plugins())
+    # Add any new Backend definitions
+    plugin_names = [plugin.name for plugin in plugins]
+    for backend in set(backends).symmetric_difference(set(plugin_names)):
+        log.info("Registering backend %r", backend)
         bcke = model.Backend(name=backend)
         session.add(bcke)
         try:
             session.commit()
         except SQLAlchemyError as err:  # pragma: no cover
             # We cannot test this as it would come from a defective DB
+            print(err)
             session.rollback()
     return plugins
 
+def _load_ecosystem_plugins(session):
+    """Load any new ecosystem plugins into the DB"""
+    ecosystems = [ecosystem.name for ecosystem in model.Ecosystem.all(session)]
+    plugins = list(ECOSYSTEM_PLUGINS.get_plugins())
+    # Add any new Ecosystem definitions
+    backends_by_ecosystem = dict((plugin.name, plugin.default_backend)
+                                 for plugin in plugins)
+    for eco_name in set(ecosystems).symmetric_difference(set(backends_by_ecosystem)):
+        backend = backends_by_ecosystem[eco_name]
+        bcke = model.Backend.by_name(session, backend)
+        log.info("Registering ecosystem %r with default backend %r",
+                 eco_name, backend)
+        ecosystem = model.Ecosystem(name=eco_name, default_backend=bcke)
+        session.add(ecosystem)
+        try:
+            session.commit()
+        except SQLAlchemyError as err:  # pragma: no cover
+            # We cannot test this as it would come from a defective DB
+            print(err)
+            session.rollback()
+    return plugins
 
-def get_plugin_names():
-    ''' Return the list of plugins names. '''
-    plugins = load('anitya.lib.backends', subclasses=BaseBackend)
-    output = [plugin.name for plugin in plugins]
-    return output
+def load_all_plugins(session):
+    ''' Load all the plugins and insert them in the database if they are
+    not already present. '''
+    plugins = {}
+    plugins["backends"] = _load_backend_plugins(session)
+    plugins["ecosystems"] = _load_ecosystem_plugins(session)
+    return plugins
 
-
-def get_plugins():
-    ''' Return the list of plugins. '''
-    return load('anitya.lib.backends', subclasses=BaseBackend)
-
-
-def get_plugin(plugin_name):
-    ''' Return the plugin corresponding to the given plugin name. '''
-    plugins = load('anitya.lib.backends', subclasses=BaseBackend)
-    for plugin in plugins:
-        if plugin.name.lower() == plugin_name.lower():
-            return plugin
+# Preserve module level API for accessing the backend plugin list
+get_plugin_names = BACKEND_PLUGINS.get_plugin_names
+get_plugins = BACKEND_PLUGINS.get_plugins
+get_plugin = BACKEND_PLUGINS.get_plugin
+def load_plugins(session):
+    ''' Calls load_all_plugins, but only returns the backends plugin list '''
+    return load_all_plugins(session)["backends"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -161,6 +161,44 @@ def create_project(session):
         user_id='noreply@fedoraproject.org',
     )
 
+def create_ecosystem_projects(session):
+    """ Create some fake projects from particular upstream ecosystems
+
+    Each project name is used in two different ecosystems
+    """
+    anitya.lib.create_project(
+        session,
+        name='pypi_and_npm',
+        homepage='https://example.com/not-a-real-pypi-project',
+        backend='PyPI',
+        user_id='noreply@fedoraproject.org'
+    )
+
+    anitya.lib.create_project(
+        session,
+        name='pypi_and_npm',
+        homepage='https://example.com/not-a-real-npmjs-project',
+        backend='npmjs',
+        user_id='noreply@fedoraproject.org'
+    )
+
+    anitya.lib.create_project(
+        session,
+        name='rubygems_and_maven',
+        homepage='https://example.com/not-a-real-rubygems-project',
+        backend='Rubygems',
+        user_id='noreply@fedoraproject.org'
+    )
+
+
+    anitya.lib.create_project(
+        session,
+        name='rubygems_and_maven',
+        homepage='https://example.com/not-a-real-maven-project',
+        backend='Maven Central',
+        user_id='noreply@fedoraproject.org'
+    )
+
 
 def create_package(session):
     """ Create some basic packages to work with. """

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -167,6 +167,25 @@ class Modeltests(Modeltests):
         backend = model.Backend.by_name(self.session, 'pypi')
         self.assertEqual(backend, None)
 
+    def test_ecosystem_by_name(self):
+        """ Test the Ecosystem.by_name function. """
+        import anitya.lib.plugins as plugins
+        plugins.load_plugins(self.session)
+        ecosystem = model.Ecosystem.by_name(self.session, 'pypi')
+        self.assertEqual(ecosystem.name, 'pypi')
+
+        ecosystem = model.Ecosystem.by_name(self.session, 'PyPI')
+        self.assertEqual(ecosystem, None)
+
+    def test_ecosystem_backend_links(self):
+        """ Test the Ecosystem.by_name function. """
+        import anitya.lib.plugins as plugins
+        plugins.load_plugins(self.session)
+        ecosystems = model.Ecosystem.all(self.session)
+        for ecosystem in ecosystems:
+            self.assertEqual(ecosystem.default_backend.default_ecosystem.name,
+                             ecosystem.name)
+
     def test_project_get_or_create(self):
         """ Test the Project.get_or_create function. """
         project = model.Project.get_or_create(


### PR DESCRIPTION
- model structured ecosystems (like PyPI or Maven Central)
  separately from version querying backends
- module level plugin APIs still just work with backend plugins
  by default
- new BACKEND_PLUGINS and ECOSYSTEM_PLUGINS plugin manager
  instances allow access to the particular kinds of plugin
- module level "load_all_plugins" API (implicitly called by the
  old "load_plugins" API) reports both kinds of plugin to caller
- ecosystem plugins can define a bidirectional "default"
  relationship with a named backend plugin
- new API endpoint allows projects to be looked up by ecosystem
  in addition to by numeric ID and by distro
- project names must be unique within a given ecosystem