### PR TITLE
Open XML as utf-8 file

### DIFF
--- a/anitya/lib/xml2dict.py
+++ b/anitya/lib/xml2dict.py
@@ -5,6 +5,7 @@ Released under the GPLv2 at https://code.google.com/archive/p/xml2dict/
 Adjusted by Pierre-Yves Chibon <pingou@pingoured.fr>
 """
 
+import codecs
 import re
 import xml.etree.ElementTree as ET
 
@@ -80,7 +81,7 @@ class XML2Dict(object):
 
     def parse(self, file):
         """parse a xml file to a dict"""
-        f = open(file, 'r')
+        f = codecs.open(file, 'r', encoding='utf=8')
         return self.fromstring(f.read())
 
     def fromstring(self, s):


### PR DESCRIPTION
I was trying to run the cron job with --check-feed, which fetched the PyPI RSS feed. At that moment, one of the packages in the feed was [1], summary of which contains non-ascii chars, thus the XML parsing failed. This PR fixes that error.

[1] https://pypi.python.org/pypi/simcu.synapse/0.1.1