### PR TITLE
Make sure we pass encoded string to elementtree parser

### DIFF
--- a/anitya/lib/xml2dict.py
+++ b/anitya/lib/xml2dict.py
@@ -5,7 +5,6 @@ Released under the GPLv2 at https://code.google.com/archive/p/xml2dict/
 Adjusted by Pierre-Yves Chibon <pingou@pingoured.fr>
 """
 
-import codecs
 import re
 import xml.etree.ElementTree as ET
 
@@ -83,7 +82,7 @@ class XML2Dict(object):
 
     def parse(self, file):
         """parse a xml file to a dict"""
-        f = codecs.open(file, 'r', encoding='utf=8')
+        f = open(file, 'rb')
         return self.fromstring(f.read())
 
     def fromstring(self, s):

--- a/anitya/lib/xml2dict.py
+++ b/anitya/lib/xml2dict.py
@@ -9,6 +9,8 @@ import codecs
 import re
 import xml.etree.ElementTree as ET
 
+import six
+
 
 class object_dict(dict):
     """object view of dict, you can
@@ -86,6 +88,8 @@ class XML2Dict(object):
 
     def fromstring(self, s):
         """parse a string"""
+        if isinstance(s, six.text_type):
+            s = s.encode('utf-8')
         t = ET.fromstring(s)
         root_tag, root_tree = self._namespace_split(
             t.tag, self._parse_node(t))


### PR DESCRIPTION
I got an error from the cron script while checking CPAN with `--check-feed` argument. The underlying issue is that while parsing the new packages feed, `requests.get(...).text` gets passed to `XML2Dict.from_string()` and then to `xml.etree.ElementTree`, which tries to encode the given argument. `requests.get(...).text` returns a unicode object. This is OK most of the time in Python 2, since unicode has both `encode` and `decode` methods. However, if the string contains non-ascii chars, `ElementTree` will fail encoding it, since it always encodes with `ascii` (prior to any other parsing). This would also always fail on Python 3, IMO.  Example:

```
>>> # this works fine
>>> ET.fromstring(u'<xml>qwe</xml>')
<Element 'xml' at 0x7f411e4916d0>
>>> # this doesn't, since it's unicode string and contains characters that can't be encoded to ascii
>>> ET.fromstring(u'<xml>ěšč</xml>')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python2.7/xml/etree/ElementTree.py", line 1311, in XML
    parser.feed(text)
  File "/usr/lib64/python2.7/xml/etree/ElementTree.py", line 1651, in feed
    self._parser.Parse(data, 0)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 5-7: ordinal not in range(128)
```
The proposed patch fixes this by encoding the given string with utf-8, assuming it's a unicode string.