### PR TITLE
Make anitya_cron use thread pool instead of process pool

### DIFF
--- a/files/anitya_cron.py
+++ b/files/anitya_cron.py
@@ -3,7 +3,14 @@
 
 import sys
 import logging
-import multiprocessing
+# We need to use multiprocessing.dummy, since we use the Pool to run
+# update_project. This in turn uses anitya.lib.backends.BaseBackend.call_url,
+# which utilizes a global requests session. Requests session is not usable
+# with multiprocessing, since it would need to share the SSL connection between
+# processes (see https://stackoverflow.com/q/3724900#3724938).
+# multiprocessing.dummy.Pool is in fact a Thread pool, which works ok
+# with a global shared requests session.
+import multiprocessing.dummy as multiprocessing
 
 import anitya
 import anitya.app


### PR DESCRIPTION
So this is probably the last error that I've hit with the cron job using `--check-feed`. The explanation is kind of long-ish (see the comment in code), but I still think it's worth putting the long comment into code, so that everyone knows why `multiprocessing.dummy` is used right away.
FTR, I think using `multiprocessing.dummy.Pool` (which is actually a thread pool) is actually ok here, since threads will lift GIL while fetching URLs, so the performance drop shouldn't be significant (although there probably _is_ some performance drop).
