### PR TITLE
Use lstrip() instead of replace() to remove the version prefix

### DIFF
--- a/anitya/lib/backends/__init__.py
+++ b/anitya/lib/backends/__init__.py
@@ -330,8 +330,7 @@ def get_versions_by_regex_for_text(text, url, regex, project):
 
     for index, version in enumerate(upstream_versions):
         # Strip the version_prefix early
-        if project.version_prefix:
-            version = version.replace(project.version_prefix, '', 1)
+        version = version.lstrip(project.version_prefix)
         upstream_versions[index] = version
 
         # If the version retrieved is a tuple, re-constitute it


### PR DESCRIPTION
Fixes https://github.com/fedora-infra/anitya/issues/319