### PR TITLE
Allow user to see the logs related to their openid or their email

### DIFF
--- a/anitya/admin.py
+++ b/anitya/admin.py
@@ -299,7 +299,6 @@ def delete_project_version(project_id, version):
 @login_required
 def browse_logs():
 
-    email = None
     if is_admin():
         user = flask.request.args.get('user', None)
     else:

--- a/anitya/admin.py
+++ b/anitya/admin.py
@@ -299,10 +299,11 @@ def delete_project_version(project_id, version):
 @login_required
 def browse_logs():
 
+    email = None
     if is_admin():
         user = flask.request.args.get('user', None)
     else:
-        user = flask.g.auth.openid
+        user = [flask.g.auth.openid, flask.g.auth.email]
 
     from_date = flask.request.args.get('from_date', None)
     project = flask.request.args.get('project', None)

--- a/anitya/lib/model.py
+++ b/anitya/lib/model.py
@@ -119,7 +119,10 @@ class Log(BASE):
             query = query.filter(cls.created_on >= from_date)
 
         if user:
-            query = query.filter(cls.user == user)
+            if isinstance(user, (list, tuple)):
+                query = query.filter(cls.user.in_(user))
+            else:
+                query = query.filter(cls.user == user)
 
         query = query.order_by(cls.created_on.desc())
 


### PR DESCRIPTION
We recently moved from using the user's email to use the user's openid
identifier as well identifier :)
This broke the logs page since non-admin can only see their logs, which
now means: see logs related to their openid. So all their old logs are
no longer accessible.
To fix this, we can simply ask to see all the logs related to either the
user's openid or the user's email.
That's what this commit does.
