### PR TITLE
Report the reason fetching a url failed in the folder backend

### DIFF
--- a/anitya/lib/backends/folder.py
+++ b/anitya/lib/backends/folder.py
@@ -64,9 +64,10 @@ class FolderBackend(BaseBackend):
 
         try:
             req = cls.call_url(url)
-        except Exception:
+        except Exception as err:
             raise AnityaPluginException(
-                'Could not call : "%s" of "%s"' % (url, project.name))
+                'Could not call : "%s" of "%s", with error: %s' % (
+                    url, project.name, str(err)))
 
         versions = None
         if not isinstance(req, six.string_types):


### PR DESCRIPTION
It was noted in https://github.com/fedora-infra/anitya/issues/338 that
FTP urls fail. In my tests, FTP connections to the host mentioned in the
issue fail occasionally when the connection is reset by the host. This
does not make the FTP call more robust, but it does report the actual
error that occurred.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>