### PR TITLE
Add a timeout to HTTP requests

### DIFF
--- a/anitya/lib/backends/__init__.py
+++ b/anitya/lib/backends/__init__.py
@@ -293,7 +293,8 @@ class BaseBackend(object):
                 'From': from_email,
             }
 
-            return http_session.get(url, headers=headers, verify=not insecure)
+            return http_session.get(url, headers=headers, timeout=60,
+                                    verify=not insecure)
 
 
 def get_versions_by_regex(url, regex, project, insecure=False):


### PR DESCRIPTION
By default, requests waits forever for a response from the server. If
the server is very slow, or something else weird happens, the request
will hang indefinitely. This commit sets the timeout[0] to be 30
seconds, which matches the FTP timeout.

[0] http://docs.python-requests.org/en/master/user/quickstart/#timeouts

Signed-off-by: Jeremy Cline <jeremy@jcline.org>