### PR TITLE
Add a style test to enforce PEP8 compliance.

### DIFF
--- a/anitya/admin.py
+++ b/anitya/admin.py
@@ -41,7 +41,7 @@ def add_distro():
             SESSION.add(distro)
             SESSION.commit()
             flask.flash('Distribution added')
-        except SQLAlchemyError as err:
+        except SQLAlchemyError:
             flask.flash(
                 'Could not add this distro, already exists?', 'error')
         return flask.redirect(

--- a/anitya/app.py
+++ b/anitya/app.py
@@ -211,11 +211,6 @@ def login():
 @OID.loginhandler
 def fedora_login():
     ''' Handles login against the Fedora OpenID server. '''
-    next_url = flask.url_for('index')
-    if 'next' in flask.request.args:
-        if is_safe_url(flask.request.args['next']):
-            next_url = flask.request.args['next']
-
     error = OID.fetch_error()
     if error:
         flask.flash('Error during login: %s' % error, 'errors')
@@ -233,11 +228,6 @@ def fedora_login():
 @OID.loginhandler
 def google_login():
     ''' Handles login via the Google OpenID. '''
-    next_url = flask.url_for('index')
-    if 'next' in flask.request.args:
-        if is_safe_url(flask.request.args['next']):
-            next_url = flask.request.args['next']
-
     error = OID.fetch_error()
     if error:
         flask.flash('Error during login: %s' % error, 'errors')
@@ -254,11 +244,6 @@ def google_login():
 @OID.loginhandler
 def yahoo_login():
     ''' Handles login via the Yahoo OpenID. '''
-    next_url = flask.url_for('index')
-    if 'next' in flask.request.args:
-        if is_safe_url(flask.request.args['next']):
-            next_url = flask.request.args['next']
-
     error = OID.fetch_error()
     if error:
         flask.flash('Error during login: %s' % error, 'errors')
@@ -348,6 +333,7 @@ def preload_docs(endpoint):
     api_docs = markupsafe.Markup(api_docs)
     return api_docs
 
+
 htmldocs = dict.fromkeys(['about', 'fedmsg'])
 for key in htmldocs:
     htmldocs[key] = preload_docs(key)
@@ -361,6 +347,6 @@ def load_docs(request):
 
 
 # Finalize the import of other controllers
-from . import api
-from . import ui
-from . import admin
+from . import api  # NOQA
+from . import ui  # NOQA
+from . import admin  # NOQA

--- a/anitya/default_config.py
+++ b/anitya/default_config.py
@@ -1,4 +1,4 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
 """
  (c) 2014 - Copyright Red Hat Inc

--- a/anitya/lib/__init__.py
+++ b/anitya/lib/__init__.py
@@ -9,12 +9,11 @@
 anitya internal library.
 """
 
-
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import logging
 import sys
+
+__requires__ = ['SQLAlchemy >= 0.7']  # NOQA
+import pkg_resources  # NOQA
 
 import sqlalchemy as sa
 from sqlalchemy import create_engine

--- a/anitya/lib/backends/pagure.py
+++ b/anitya/lib/backends/pagure.py
@@ -60,7 +60,7 @@ class PagureBackend(BaseBackend):
         try:
             req = cls.call_url(url)
         except Exception as err:  # pragma: no cover
-            raise AnityaPluginException('Could not contact %s' % url)
+            raise AnityaPluginException('Could not contact %s: %s' % (url, str(err)))
 
         try:
             data = req.json()

--- a/anitya/lib/backends/stackage.py
+++ b/anitya/lib/backends/stackage.py
@@ -7,7 +7,7 @@
 """
 
 
-from anitya.lib.backends import BaseBackend, get_versions_by_regex, REGEX
+from anitya.lib.backends import BaseBackend, get_versions_by_regex
 
 
 class StackageBackend(BaseBackend):

--- a/anitya/lib/model.py
+++ b/anitya/lib/model.py
@@ -9,13 +9,12 @@
 anitya mapping of python classes to Database Tables.
 """
 
-
-__requires__ = ['SQLAlchemy >= 0.7']
-import pkg_resources
-
 import datetime
 import logging
 import time
+
+__requires__ = ['SQLAlchemy >= 0.7']  # NOQA
+import pkg_resources  # NOQA
 
 import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declarative_base

--- a/anitya/lib/plugins.py
+++ b/anitya/lib/plugins.py
@@ -45,6 +45,7 @@ class _PluginManager(object):
             if plugin.name.lower() == plugin_name.lower():
                 return plugin
 
+
 BACKEND_PLUGINS = _PluginManager('anitya.lib.backends', BaseBackend)
 ECOSYSTEM_PLUGINS = _PluginManager('anitya.lib.ecosystems', BaseEcosystem)
 
@@ -100,6 +101,7 @@ def load_all_plugins(session):
     plugins["backends"] = _load_backend_plugins(session)
     plugins["ecosystems"] = _load_ecosystem_plugins(session)
     return plugins
+
 
 # Preserve module level API for accessing the backend plugin list
 get_plugin_names = BACKEND_PLUGINS.get_plugin_names

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -252,7 +252,7 @@ def projects_search(pattern=None):
             SESSION, pattern=get_extended_pattern(pattern), count=True)
     else:
         projects_count = anitya.lib.model.Project.search(
-            SESSION, pattern=pattern, distro=distroname, count=True)
+            SESSION, pattern=pattern, count=True)
 
     if projects_count == 1 and projects[0].name == pattern.replace('*', ''):
         flask.flash(

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,7 @@
-vcrpy
-nose
 coverage
+flake8
+nose
+vcrpy
 
 # required by vcs looks like
 mock

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA  02110-1301, USA.
+"""This module runs flake8 on the entire code base"""
+
+import os
+import subprocess
+import unittest
+
+
+REPO_PATH = os.path.abspath(
+    os.path.dirname(os.path.join(os.path.dirname(__file__), '../')))
+
+
+class TestStyle(unittest.TestCase):
+    """
+    Run flake8 on the repository directory as part of the unit tests.
+
+    This currently only checks the anitya package, not the unit tests.
+    The unit tests will be incrementally styled.
+    """
+
+    def test_code_with_flake8(self):
+        """Assert the code is PEP8-compliant"""
+        enforced_paths = [
+            'anitya/',
+        ]
+
+        enforced_paths = [os.path.join(REPO_PATH, p) for p in enforced_paths]
+
+        flake8_command = ['flake8', '--max-line-length', '100'] + enforced_paths
+        self.assertEqual(subprocess.call(flake8_command), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ sitepackages = True
 # Need to ensure all PyPI published dependencies are installed in the venv
 install_command = pip install --ignore-installed {opts} {packages}
 deps =
+    flake8
     nose
     vcrpy
 # tox doesn't appear to understand environment markers properly yet,


### PR DESCRIPTION
This adds a test to enforce PEP8 compliance and fixes all the violations
in the anitya package. This does not fix the unit tests and style is not
currently enforced there. They can be incrementally fixed and added to
the enforced paths list.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>