### PR TITLE
replace lstrip() with proper chopping

### DIFF
--- a/anitya/lib/backends/__init__.py
+++ b/anitya/lib/backends/__init__.py
@@ -336,7 +336,8 @@ def get_versions_by_regex_for_text(text, url, regex, project):
             version = ".".join([v for v in version if not v == ""])
 
         # Strip the version_prefix early
-        version = version.lstrip(project.version_prefix)
+        if version.startswith(project.version_prefix):
+            version = version[len(project.version_prefix):]
         upstream_versions[index] = version
 
         if " " in version:


### PR DESCRIPTION
Doing lstrip() is wrong in such situation, e.g. "libgphoto2-2.1.15.tar.gz".lstrip("libgphoto2-") -> ".1.15.tar.gz"