### PR TITLE
Projects with the folders backend can use insecure HTTPS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ dev (master)
 
 * Return 4XX codes in error cases for /projects/new rather than 200 (Issue #246)
 
+* Allow projecst using the "folder" backend to make insecure HTTPS requests
+  (Issue #386)
+
+* Fix an issue where turning the insecure flag on and then off for a project
+  resulted in insecure requests until the server was restarted (Issue #394)
+
 * [insert summary of change here]
 
 

--- a/anitya/lib/backends/folder.py
+++ b/anitya/lib/backends/folder.py
@@ -63,7 +63,7 @@ class FolderBackend(BaseBackend):
         url = project.version_url
 
         try:
-            req = cls.call_url(url)
+            req = cls.call_url(url, insecure=project.insecure)
         except Exception as err:
             raise AnityaPluginException(
                 'Could not call : "%s" of "%s", with error: %s' % (

--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -131,6 +131,7 @@
 
     if (str == 'folder'){
       $('#version_url_row').show();
+      $('#insecure_row').show();
     };
     if (str == 'GitHub'){
       $("label[for='version_url']").text('GitHub owner/project');

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -30,6 +30,37 @@ import mock
 
 from anitya.lib import backends
 from anitya.lib.exceptions import AnityaPluginException
+import anitya
+
+
+class BaseBackendTests(unittest.TestCase):
+
+    def setUp(self):
+        self.backend = backends.BaseBackend()
+        self.headers = {
+            'User-Agent': 'Anitya {0} at upstream-monitoring.org'.format(
+                anitya.app.__version__),
+            'From': anitya.app.APP.config.get('ADMIN_EMAIL'),
+        }
+
+    @mock.patch('anitya.lib.backends.http_session')
+    def test_call_http_url(self, mock_http_session):
+        """Assert HTTP urls are handled by requests"""
+        url = 'http://www.example.com/'
+        self.backend.call_url(url)
+
+        mock_http_session.get.assert_called_once_with(
+            url, headers=self.headers, timeout=60, verify=True)
+
+    @mock.patch('anitya.lib.backends.requests.Session')
+    def test_call_insecure_http_url(self, mock_session):
+        """Assert HTTP urls are handled by requests"""
+        url = 'https://www.example.com/'
+        self.backend.call_url(url, insecure=True)
+
+        insecure_session = mock_session.return_value.__enter__.return_value
+        insecure_session.get.assert_called_once_with(
+            url, headers=self.headers, timeout=60, verify=False)
 
 
 class GetVersionsByRegexTextTests(unittest.TestCase):


### PR DESCRIPTION
Projects have a flag to allow for insecure HTTPS connections where the
signature on the certificate presented by the server is not verified.
This enables users to set that flag when creating or editing projects
using the folder backend. The reason for this is that the backend URL
can be any page on the Internet and there's no guarantee that user is
serving a certificate signed by a trusted CA (or they might have messed
up their configuration).

fixes #386

Signed-off-by: Jeremy Cline <jeremy@jcline.org>