### PR TITLE
Insert the repo path into the Python path for the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,11 @@
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('../'))  # NOQA
+
 from anitya import app
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,6 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.viewcode',
-    'sphinx.ext.githubpages',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
This is motivated by readthedocs, which is having trouble installings
the package since it doesn't install with pip and fails to understand
the ``python_version < '3.0'`` directive.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>