### PR TITLE
Refactor anitya.app to move Flask routes

### DIFF
--- a/anitya/app.py
+++ b/anitya/app.py
@@ -1,33 +1,28 @@
 # -*- coding: utf-8 -*-
 
 """
-The main file for the application.
-This file creates the flask application and contains the functions used to
-check if the user is an admin and other utility functions.
+This module is responsible for creating and configuring the flask application
+object. This includes loading any provided configuration and merging it with
+the default configuration, loading and configuring Flask extensions, and
+configuring logging.
+
+User-facing Flask routes should be placed in the ``anitya.ui`` module and API
+routes should be placed in ``anitya.api``.
 """
 
 
-import codecs
 import functools
 import logging
 import logging.handlers
 import os
 import sys
-import six.moves.urllib.parse as urlparse
 
-import docutils
-import docutils.examples
 import flask
-import jinja2
-import markupsafe
 from bunch import Bunch
 from flask.ext.openid import OpenID
 
-import anitya.forms
 import anitya.lib
-import anitya.lib.plugins
 import anitya.mail_logging
-from six.moves import map
 
 
 __version__ = '0.10.1'
@@ -40,7 +35,7 @@ if 'ANITYA_WEB_CONFIG' in os.environ:  # pragma: no cover
     APP.config.from_envvar('ANITYA_WEB_CONFIG')
 
 # Set up OpenID
-OID = OpenID(APP)
+APP.oid = OpenID(APP)
 
 # Set up the logging
 if not APP.debug:
@@ -107,7 +102,7 @@ def check_auth():
         flask.g.auth.email = flask.session.get('email', None)
 
 
-@OID.after_login
+@APP.oid.after_login
 def after_openid_login(resp):
     ''' This function saved the information about the user right after the
     login was successful on the OpenID server.
@@ -178,172 +173,6 @@ def inject_variable():
         justedit=justedit,
         cron_status=cron_status,
     )
-
-
-@APP.route('/login/', methods=('GET', 'POST'))
-@APP.route('/login', methods=('GET', 'POST'))
-@OID.loginhandler
-def login():
-    ''' Handle the login when no OpenID server have been selected in the
-    list.
-    '''
-    next_url = flask.url_for('index')
-    if 'next' in flask.request.args:
-        if is_safe_url(flask.request.args['next']):
-            next_url = flask.request.args['next']
-
-    OID.store_factory = lambda: None
-    if flask.g.auth.logged_in:
-        return flask.redirect(next_url)
-
-    openid_server = flask.request.form.get('openid', None)
-    if openid_server:
-        return OID.try_login(
-            openid_server, ask_for=['email', 'fullname', 'nickname'])
-
-    return flask.render_template(
-        'login.html',
-        next=OID.get_next_url(), error=OID.fetch_error())
-
-
-@APP.route('/login/fedora/', methods=('GET', 'POST'))
-@APP.route('/login/fedora', methods=('GET', 'POST'))
-@OID.loginhandler
-def fedora_login():
-    ''' Handles login against the Fedora OpenID server. '''
-    error = OID.fetch_error()
-    if error:
-        flask.flash('Error during login: %s' % error, 'errors')
-        return flask.redirect(flask.url_for('index'))
-
-    OID.store_factory = lambda: None
-    return OID.try_login(
-        APP.config['ANITYA_WEB_FEDORA_OPENID'],
-        ask_for=['email', 'nickname'],
-        ask_for_optional=['fullname'])
-
-
-@APP.route('/login/google/', methods=('GET', 'POST'))
-@APP.route('/login/google', methods=('GET', 'POST'))
-@OID.loginhandler
-def google_login():
-    ''' Handles login via the Google OpenID. '''
-    error = OID.fetch_error()
-    if error:
-        flask.flash('Error during login: %s' % error, 'errors')
-        return flask.redirect(flask.url_for('index'))
-
-    OID.store_factory = lambda: None
-    return OID.try_login(
-        "https://www.google.com/accounts/o8/id",
-        ask_for=['email', 'fullname'])
-
-
-@APP.route('/login/yahoo/', methods=('GET', 'POST'))
-@APP.route('/login/yahoo', methods=('GET', 'POST'))
-@OID.loginhandler
-def yahoo_login():
-    ''' Handles login via the Yahoo OpenID. '''
-    error = OID.fetch_error()
-    if error:
-        flask.flash('Error during login: %s' % error, 'errors')
-        return flask.redirect(flask.url_for('index'))
-
-    OID.store_factory = lambda: None
-    return OID.try_login(
-        "https://me.yahoo.com/",
-        ask_for=['email', 'fullname'])
-
-
-@APP.route('/logout/')
-@APP.route('/logout')
-def logout():
-    ''' Logout the user. '''
-    flask.session.pop('openid')
-    next_url = flask.url_for('index')
-    if 'next' in flask.request.args:
-        if is_safe_url(flask.request.args['next']):
-            next_url = flask.request.args['next']
-
-    return flask.redirect(next_url)
-
-
-def is_safe_url(target):
-    """ Checks that the target url is safe and sending to the current
-    website not some other malicious one.
-    """
-    ref_url = urlparse.urlparse(flask.request.host_url)
-    test_url = urlparse.urlparse(
-        urlparse.urljoin(flask.request.host_url, target))
-    return test_url.scheme in ('http', 'https') and \
-        ref_url.netloc == test_url.netloc
-
-
-def modify_rst(rst):
-    ''' Downgrade some of our rst directives if docutils is too old. '''
-
-    try:
-        # The rst features we need were introduced in this version
-        minimum = [0, 9]
-        version = list(map(int, docutils.__version__.split('.')))
-
-        # If we're at or later than that version, no need to downgrade
-        if version >= minimum:
-            return rst
-    except Exception:
-        # If there was some error parsing or comparing versions, run the
-        # substitutions just to be safe.
-        pass
-
-    # Otherwise, make code-blocks into just literal blocks.
-    substitutions = {
-        '.. code-block:: javascript': '::',
-    }
-    for old, new in substitutions.items():
-        rst = rst.replace(old, new)
-
-    return rst
-
-
-def modify_html(html):
-    ''' Perform style substitutions where docutils doesn't do what we want.
-    '''
-
-    substitutions = {
-        '<tt class="docutils literal">': '<code>',
-        '</tt>': '</code>',
-    }
-    for old, new in substitutions.items():
-        html = html.replace(old, new)
-
-    return html
-
-
-def preload_docs(endpoint):
-    ''' Utility to load an RST file and turn it into fancy HTML. '''
-
-    here = os.path.dirname(os.path.abspath(__file__))
-    fname = os.path.join(here, 'docs', endpoint + '.rst')
-    with codecs.open(fname, 'r', 'utf-8') as f:
-        rst = f.read()
-
-    rst = modify_rst(rst)
-    api_docs = docutils.examples.html_body(rst)
-    api_docs = modify_html(api_docs)
-    api_docs = markupsafe.Markup(api_docs)
-    return api_docs
-
-
-htmldocs = dict.fromkeys(['about', 'fedmsg'])
-for key in htmldocs:
-    htmldocs[key] = preload_docs(key)
-
-
-def load_docs(request):
-    URL = request.url_root
-    docs = htmldocs[request.endpoint]
-    docs = jinja2.Template(docs).render(URL=URL)
-    return markupsafe.Markup(docs)
 
 
 # Finalize the import of other controllers


### PR DESCRIPTION
This refactors the ``anitya.app`` module to remove the Flask route
handlers. These have been moved to the ``anitya.ui`` module.
``anitya.app`` has been documented to be exclusively for application
setup.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>