### PR TITLE
Correctly disable fedmsg signatures for local dev

### DIFF
--- a/fedmsg.d/fedmsg-config.py
+++ b/fedmsg.d/fedmsg-config.py
@@ -25,5 +25,5 @@ config = dict(
     zmq_strict=False,
 
     sign_messages=False,
-    validate_messages=False,
+    validate_signatures=False,
 )


### PR DESCRIPTION
The setting to turn off signature validation during development
is `validate_signatures` rather than `validate_messages`.