### PR TITLE
Data migration for by_ecosystem query

### DIFF
--- a/alembic/versions/9c29da0af3af_populate_ecosystem_data.py
+++ b/alembic/versions/9c29da0af3af_populate_ecosystem_data.py
@@ -1,0 +1,36 @@
+"""Populate missing ecosystem data
+
+Revision ID: 9c29da0af3af
+Revises: 921c612ba0da
+Create Date: 2017-01-11 22:23:58.497998
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '9c29da0af3af'
+down_revision = '921c612ba0da'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    # We use a subquery instead of an UPDATE FROM with a table join
+    # due to the fact that SQLite doesn't allow joins in update statements
+    op.execute("""
+        UPDATE projects
+        SET ecosystem_name=(
+            SELECT ecosystems.name
+            FROM projects AS subquery_projects
+                INNER JOIN ecosystems ON
+                    subquery_projects.backend = ecosystems.default_backend_name
+            WHERE projects.id = subquery_projects.id
+        )
+        WHERE ecosystem_name is null
+    """)
+
+
+def downgrade():
+    # Do nothing on downgrade - column removal will be handled by previous
+    # revision
+    pass


### PR DESCRIPTION
This migration allows pre-existing projects to be looked
up via the by_ecosystem API endpoint.