### PR TITLE
Update the Debian backend to strip .orig suffix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ dev (master)
   can fail if existing data has duplicate projects since there is a new
   constraint that a project name is unique within an ecosystem (Issue #402).
 
+* Fix the regular expression used with the Debian backend to strip the "orig"
+  being incorrectly included in the version (Issue #398)
+
 * [insert summary of change here]
 
 

--- a/anitya/lib/backends/debian.py
+++ b/anitya/lib/backends/debian.py
@@ -8,7 +8,16 @@
 
 """
 
-from anitya.lib.backends import BaseBackend, get_versions_by_regex, REGEX
+from anitya.lib.backends import BaseBackend, get_versions_by_regex
+
+
+# Debian packagers upload the original source tarball in the format
+# <name>_<version>.orig.<compression format>. So, for example,
+# reprepro_4.13.1.orig.tar.gz.
+DEBIAN_REGEX = (
+    '%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?)(?i)(?:[-_]'
+    '(?:minsrc|src|source|asc))?\.(?:orig\.)?(?:tar|t[bglx]z|tbz2|zip)'
+)
 
 
 class DebianBackend(BaseBackend):
@@ -64,6 +73,6 @@ class DebianBackend(BaseBackend):
             short = project.name[0]
 
         url = url_template % {'short': short, 'name': project.name}
-        regex = REGEX % {'name': project.name}
+        regex = DEBIAN_REGEX % {'name': project.name}
 
         return get_versions_by_regex(url, regex, project)

--- a/tests/request-data/tests.test_backend_debian.DebianBackendtests.test_get_versions_http_404
+++ b/tests/request-data/tests.test_backend_debian.DebianBackendtests.test_get_versions_http_404
@@ -1,0 +1,40 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      From: [admin@fedoraproject.org]
+      User-Agent: [Anitya 0.10.1 at upstream-monitoring.org]
+    method: GET
+    uri: http://ftp.debian.org/debian/pool/main/f/foo/
+  response:
+    body: {string: !!python/unicode '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+
+        <html><head>
+
+        <title>404 Not Found</title>
+
+        </head><body>
+
+        <h1>Not Found</h1>
+
+        <p>The requested URL /debian/pool/main/f/foo/ was not found on this server.</p>
+
+        <hr>
+
+        <address>Apache Server at ftp.debian.org Port 80</address>
+
+        </body></html>
+
+        '}
+    headers:
+      connection: [Keep-Alive]
+      content-length: ['285']
+      content-type: [text/html; charset=iso-8859-1]
+      date: ['Wed, 11 Jan 2017 21:14:13 GMT']
+      keep-alive: ['timeout=5, max=100']
+      server: [Apache]
+    status: {code: 404, message: Not Found}
+version: 1

--- a/tests/request-data/tests.test_backend_debian.DebianBackendtests.test_get_versions_no_z_release
+++ b/tests/request-data/tests.test_backend_debian.DebianBackendtests.test_get_versions_no_z_release
@@ -1,0 +1,39 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      From: [admin@fedoraproject.org]
+      User-Agent: [Anitya 0.10.1 at upstream-monitoring.org]
+    method: GET
+    uri: http://ftp.debian.org/debian/pool/main/libg/libgnupg-interface-perl/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA8WYXW+bMBSG7/crzrjYHdiYjy4pYeqSTovWplGbaZqmqXLAAasEkHG7tr9+JiQa
+        XZuEREjc5EO8Pnmf43N8FHvvR1fD2c/pOXydXV7A9Pvni/EQNB2hH9YQodFsVD2wDAJfeEoThM4n
+        mv/Oi+Uy8d+BFzMaqnfwJJcJ88dpyB4hWwAK2ZzTFOVZlqAl5SlK+DxavaT3eaTzVDKxoAHTcyYS
+        D1XLVUC0jujNs/Cp/CHz+KBq7coana9ilx+F78kYHmjCo3SgySzXfI8vIyhEMNAQD7K0QPOEpndG
+        xBca0EQOtF/j4dVvpUMyLlf7HoVYsMVA+zQcTE6vBiPNn9Al8xB9W3OpNGeaf0ELCcss5AvOwq3i
+        m0p8w59rAZHyXfcfZEmRUwVgK1uxqKsqSbgPkQYvCKdn1+eT2Wh8XXGGZYh/trbkXfOnVLBUwogL
+        FshMPK0dV8s/pPMiP918hbUfwaNYaj6ADtWjA1wH2TIXrChYWPeu8vKm6y1lcYsN29FNo2IyJBVG
+        9Kz5h6jrmP9xEWyauol14oLZ65snAFuEjkG+HZyA+/Quzf6kbdAXwX7mImiDlHRKekuTpNy9fbQb
+        XRvEcGIfTtxecRuZ8tGosOvKVsBdt6OtdrBu1Zv0cSf5a/VuelvHPR2bJb3KwfaWtjql393SG00b
+        pMQwOyRt0tJ1XRvER1V2Wy3t4KYt/VK5F9zSTRsI7uNd4F2d3g7RnQNa+pV6N71bbrs6yhS9bW+n
+        N7ul39PSa00bpMQ4Yma1RtqopWu6hsRWH+Pte+v0uiN2D6ps97DKVtOaWEBI39zR1wR3Sr+3st0m
+        ld2ElBhOh6QNK9ttWtlrYmvnqXVMZbc2rEjjYUWaDytHx7ZOTgD3+pbTdFg1/MeM1hcEHg3DMgP+
+        WU6DmMENEw9MAJWwkPmmAzMRwTQTEj5i5Xi9QMVYXVd4qLoX+QsB6Ia/VxEAAA==
+    headers:
+      connection: [Keep-Alive]
+      content-encoding: [gzip]
+      content-length: ['730']
+      content-type: [text/html;charset=UTF-8]
+      date: ['Wed, 11 Jan 2017 21:14:14 GMT']
+      keep-alive: ['timeout=5, max=100']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-clacks-overhead: [GNU Terry Pratchett]
+    status: {code: 200, message: OK}
+version: 1


### PR DESCRIPTION
Debian tarballs have a '.orig' suffix in their tarballs that we
previously didn't account for.

fixes #398

Signed-off-by: Jeremy Cline <jeremy@jcline.org>