### PR TITLE
Load the production database dump in Vagrant

### DIFF
--- a/ansible/roles/anitya-dev/files/anitya.service
+++ b/ansible/roles/anitya-dev/files/anitya.service
@@ -4,7 +4,10 @@ After=network.target
 Documentation=https://github.com/fedora-infra/anitya/
 
 [Service]
-ExecStart=/home/vagrant/.virtualenvs/anitya/bin/python %h/devel/runserver.py --host 0.0.0.0 --port 5000
+Environment="FLASK_APP=/home/vagrant/devel/anitya/app.py"
+Environment="FLASK_DEBUG=1"
+Environment="ANITYA_WEB_CONFIG=/home/vagrant/flask_config.py"
+ExecStart=/home/vagrant/.virtualenvs/anitya/bin/flask run --host 0.0.0.0 --port 5000
 Type=simple
 
 [Install]

--- a/ansible/roles/anitya-dev/files/config.py
+++ b/ansible/roles/anitya-dev/files/config.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+# URL to the database
+DB_URL = 'postgresql://postgres:anypasswordworkslocally@localhost/anitya'
+
+# List of admins based on their openid
+# ANITYA_WEB_ADMINS = ['http://<FAS>.id.fedoraproject.org/']
+
+# Fedora OpenID endpoint
+ANITYA_WEB_FEDORA_OPENID = 'https://id.fedoraproject.org'
+
+# Booleans to activate or not OpenID providers
+ANITYA_WEB_ALLOW_FAS_OPENID = True
+ANITYA_WEB_ALLOW_GOOGLE_OPENID = True
+ANITYA_WEB_ALLOW_YAHOO_OPENID = True
+ANITYA_WEB_ALLOW_GENERIC_OPENID = True
+
+ADMIN_EMAIL = 'admin@fedoraproject.org'
+
+BLACKLISTED_USERS = []

--- a/ansible/roles/anitya-dev/tasks/db.yml
+++ b/ansible/roles/anitya-dev/tasks/db.yml
@@ -1,0 +1,60 @@
+---
+- name: Install database packages
+  dnf:
+      name: "{{ item }}"
+      state: present
+  with_items:
+      - postgresql-server
+      - postgresql-devel
+      - postgresql
+
+- name: Initialize PostgreSQL
+  command: postgresql-setup initdb
+  args:
+      creates: /var/lib/pgsql/data/pg_hba.conf
+
+- replace:
+    dest: /var/lib/pgsql/data/pg_hba.conf
+    regexp: "host    all             all             127.0.0.1/32            ident"
+    replace: "host    all             all             127.0.0.1/32            trust"
+
+- replace:
+    dest: /var/lib/pgsql/data/pg_hba.conf
+    regexp: "host    all             all             ::1/128                 ident"
+    replace: "host    all             all             ::1/128                 trust"
+
+- service:
+    name: postgresql
+    state: started
+    enabled: yes
+
+- name: Create a database for Anitya
+  shell: runuser -l postgres -c 'createdb anitya' && touch /home/vagrant/.db-created
+  args:
+      creates: /home/vagrant/.db-created
+
+- name: Retrieve database dump
+  get_url:
+      url: https://infrastructure.fedoraproject.org/infra/db-dumps/anitya.dump.xz
+      dest: /tmp/anitya.dump.xz
+
+- shell: xzcat /tmp/anitya.dump.xz | runuser -l postgres -c 'psql anitya' && touch /home/vagrant/.db-imported
+  args:
+      creates: /home/vagrant/.db-imported
+
+- name: Create /home/vagrant/alembic.ini
+  copy: src=/home/vagrant/devel/alembic.ini dest=/home/vagrant/alembic.ini remote_src=True
+
+
+- name: Switch the database connection to postgres
+  replace:
+    dest: /home/vagrant/alembic.ini
+    regexp: "^sqlalchemy.url = sqlite.*$"
+    replace: "sqlalchemy.url = postgresql://postgres:anypasswordworkslocally@localhost/anitya"
+
+- name: Apply database migrations
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  command: ~/.virtualenvs/anitya/bin/alembic upgrade head
+  args:
+      chdir: /home/vagrant/devel
+

--- a/ansible/roles/anitya-dev/tasks/main.yml
+++ b/ansible/roles/anitya-dev/tasks/main.yml
@@ -25,6 +25,7 @@
     - python-flask-wtf
     - python-markupsafe
     - python-openid
+    - python-psycopg2
     - python-setuptools
     - python-straight-plugin
     - python-sqlalchemy
@@ -40,6 +41,9 @@
 - name: Install the message of the day
   copy: src=motd dest=/etc/motd
 
+- name: Install Anitya flask configuration
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  copy: src=config.py dest=/home/{{ ansible_env.SUDO_USER }}/flask_config.py
 
 - name: Create Anitya virtualenv
   become_user: "{{ ansible_env.SUDO_USER }}"
@@ -75,21 +79,6 @@
     virtualenv: /home/{{ ansible_env.SUDO_USER }}/.virtualenvs/anitya/
     virtualenv_python: python2
 
-- name: Create the Anitya SQLite database
-  become_user: "{{ ansible_env.SUDO_USER }}"
-  command: .virtualenvs/anitya/bin/python devel/createdb.py
-  args:
-    creates: /var/tmp/anitya-dev.sqlite
-    chdir: "/home/{{ ansible_env.SUDO_USER }}/"
-
-- name: Stamp the database with its current migration
-  become_user: "{{ ansible_env.SUDO_USER }}"
-  shell: >
-      ~/.virtualenvs/anitya/bin/alembic stamp
-      $(~/.virtualenvs/anitya/bin/alembic heads | awk '{ print $1 }')
-  args:
-    chdir: "/home/{{ ansible_env.SUDO_USER }}/devel/"
-
 - name: Create user systemd directory
   become_user: "{{ ansible_env.SUDO_USER }}"
   file:
@@ -101,3 +90,5 @@
   copy:
     src: anitya.service
     dest: /home/{{ ansible_env.SUDO_USER }}/.config/systemd/user/anitya.service
+
+- include: db.yml


### PR DESCRIPTION
This was inspired by Bodhi's Ansible role for its Vagrant environment
(thanks @bowlofeggs). It downloads the production database dump and
loads it into Postgres in the Vagrant VM. This allows developers to have
a nicely pre-populated development environment.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>