### PR TITLE
Add path argument for sourceforge RSS feeds

### DIFF
--- a/anitya/lib/backends/sourceforge.py
+++ b/anitya/lib/backends/sourceforge.py
@@ -55,7 +55,7 @@ class SourceforgeBackend(BaseBackend):
             when the versions cannot be retrieved correctly
 
         '''
-        url_template = 'http://sourceforge.net/projects/%(name)s/rss?limit=200'
+        url_template = 'https://sourceforge.net/projects/%(name)s/rss?path=/%{name}s&limit=200'
 
         url = url_template % {
             'name': (project.version_url or project.name).replace('+', '\+')


### PR DESCRIPTION
The sourceforge RSS feeds seem to need a `path=/project` parameter now, or they just return a 404 error.