### PR TITLE
Remove the system installation of Sphinx in Vagrant

### DIFF
--- a/ansible/roles/anitya-dev/tasks/main.yml
+++ b/ansible/roles/anitya-dev/tasks/main.yml
@@ -4,7 +4,6 @@
   dnf: name={{ item }} state=present
   with_items:
     - git
-    - python-sphinx
     - python-virtualenvwrapper
     - vim-enhanced
 
@@ -15,6 +14,7 @@
     - gcc
     - libffi-devel
     - openssl-devel
+    - postgresql-devel
     - python2-devel
     - python3-devel
     - redhat-rpm-config

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,3 +6,7 @@ vcrpy
 # required by vcs looks like
 mock
 contextlib2
+
+# Required to test building the docs
+sphinx
+sphinxcontrib-httpdomain


### PR DESCRIPTION
The sphinx-build binary is provided by the system installation of
Sphinx, but because we currently have to use the virtualenv with
--site-packages it causes the system installation of sphinx-build to get
called in the docs builder which fails because all the libs are in the
virtualenv.

I also noticed that the postgres headers were not installed and we're no
longer using the system postgres driver.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>