### PR TITLE
Move Anitya to fedora-infra organization

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @release-monitoring
+*   @fedora-infra/anitya

--- a/README.rst
+++ b/README.rst
@@ -9,20 +9,20 @@
   :alt: Documentation Status
   :target: https://anitya.readthedocs.io/en/latest/?badge=latest
 
-.. image:: https://codecov.io/gh/release-monitoring/anitya/branch/master/graph/badge.svg
-  :target: https://codecov.io/gh/release-monitoring/anitya
+.. image:: https://codecov.io/gh/fedora-infra/anitya/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/fedora-infra/anitya
   
-.. image:: https://travis-ci.org/release-monitoring/anitya.svg?branch=master
-  :target: https://travis-ci.org/release-monitoring/anitya
+.. image:: https://travis-ci.org/fedora-infra/anitya.svg?branch=master
+  :target: https://travis-ci.org/fedora-infra/anitya
   
-.. image:: https://img.shields.io/lgtm/alerts/g/release-monitoring/anitya.svg?logo=lgtm&logoWidth=18
-  :target: https://lgtm.com/projects/g/release-monitoring/anitya/alerts/
+.. image:: https://img.shields.io/lgtm/alerts/g/fedora-infra/anitya.svg?logo=lgtm&logoWidth=18
+  :target: https://lgtm.com/projects/g/fedora-infra/anitya/alerts/
 
-.. image:: https://img.shields.io/lgtm/grade/javascript/g/release-monitoring/anitya.svg?logo=lgtm&logoWidth=18
-  :target: https://lgtm.com/projects/g/release-monitoring/anitya/context:javascript
+.. image:: https://img.shields.io/lgtm/grade/javascript/g/fedora-infra/anitya.svg?logo=lgtm&logoWidth=18
+  :target: https://lgtm.com/projects/g/fedora-infra/anitya/context:javascript
   
-.. image:: https://img.shields.io/lgtm/grade/python/g/release-monitoring/anitya.svg?logo=lgtm&logoWidth=18
-  :target: https://lgtm.com/projects/g/release-monitoring/anitya/context:python
+.. image:: https://img.shields.io/lgtm/grade/python/g/fedora-infra/anitya.svg?logo=lgtm&logoWidth=18
+  :target: https://lgtm.com/projects/g/fedora-infra/anitya/context:python
   
 
 ======

--- a/anitya/templates/master.html
+++ b/anitya/templates/master.html
@@ -201,9 +201,9 @@
         Anitya ({{ version }}):
         <a href="{{ url_for('anitya_apiv1.api') }}">API</a>
         --
-        <a href="https://github.com/release-monitoring/anitya">sources</a>
+        <a href="https://github.com/fedora-infra/anitya">sources</a>
         --
-        <a href="https://github.com/release-monitoring/anitya/issues">issue tracker</a>
+        <a href="https://github.com/fedora-infra/anitya/issues">issue tracker</a>
         .
         ©2013-2019 Red Hat, Inc., <a href="http://pingoured.fr">pingou</a>.
         {% if cron_status %}

--- a/anitya/tests/lib/test_utilities.py
+++ b/anitya/tests/lib/test_utilities.py
@@ -441,7 +441,7 @@ class CheckProjectReleaseTests(DatabaseTestCase):
     @mock.patch.dict("anitya.config.config", {"GITHUB_ACCESS_TOKEN": "foobar"})
     def test_check_project_version_too_long(self):
         """
-        Regression test for https://github.com/release-monitoring/anitya/issues/674
+        Regression test for https://github.com/fedora-infra/anitya/issues/674
         Crash when version is too long
         """
         project = models.Project(

--- a/anitya/tests/lib/versions/test_calver.py
+++ b/anitya/tests/lib/versions/test_calver.py
@@ -578,7 +578,7 @@ class CalendarVersionTests(unittest.TestCase):
     def test_lt_no_delimiter(self):
         """
         Assert CalendarVersion supports < comparison by full pattern.
-        Bug https://github.com/release-monitoring/anitya/issues/867.
+        Bug https://github.com/fedora-infra/anitya/issues/867.
         """
         old_version = calver.CalendarVersion(version="20191018", pattern="YYYY0M0D")
         new_version = calver.CalendarVersion(version="20191213", pattern="YYYY0M0D")

--- a/anitya_schema/setup.py
+++ b/anitya_schema/setup.py
@@ -30,7 +30,7 @@ setup(
     version="1.0.0",
     description="JSON schema definitions for messages published by Anitya",
     long_description=README,
-    url="https://github.com/release-monitoring/anitya/",
+    url="https://github.com/fedora-infra/anitya/",
     # Possible options are at https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -10,9 +10,9 @@
       &copy;{{ copyright }}.|
       Powered by <a href="http://sphinx-doc.org/">Sphinx {{ sphinx_version }}</a>
       &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster {{ alabaster_version }}</a>
-      (<a href="https://github.com/release-monitoring/anitya/tree/master/docs/_templates">customized</a>)
+      (<a href="https://github.com/fedora-infra/anitya/tree/master/docs/_templates">customized</a>)
       |
-      <a href="https://github.com/release-monitoring/anitya/tree/master/docs/{{ pagename + ".rst"|e }}"
+      <a href="https://github.com/fedora-infra/anitya/tree/master/docs/{{ pagename + ".rst"|e }}"
           rel="nofollow">{{ _('View source') }}</a>
     </div>
 {%- endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -150,7 +150,7 @@ html_theme = "alabaster"
 # html_theme_options = {}
 html_theme_options = {
     "logo_name": True,
-    "github_user": "release-monitoring",
+    "github_user": "fedora-infra",
     "github_repo": "anitya",
     "page_width": "1040px",
 }

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -3,7 +3,7 @@ Development Guide
 =================
 
 Anitya welcomes contributions! Our issue tracker is located on
-`GitHub <https://github.com/release-monitoring/anitya/issues>`_.
+`GitHub <https://github.com/fedora-infra/anitya/issues>`_.
 
 
 Contribution Guidelines
@@ -104,7 +104,7 @@ To get started, install Vagrant and Ansible. On Fedora::
 
 Next, clone the repository and configure your Vagrantfile::
 
-    $ git clone https://github.com/release-monitoring/anitya.git
+    $ git clone https://github.com/fedora-infra/anitya.git
     $ cd anitya
     $ cp Vagrantfile.example Vagrantfile
     $ vagrant up
@@ -152,7 +152,7 @@ Python virtualenv
 
 Anitya can also be run in a Python virtualenv. For Fedora::
 
-    $ git clone https://github.com/release-monitoring/anitya.git
+    $ git clone https://github.com/fedora-infra/anitya.git
     $ cd anitya
     $ sudo dnf install python3-virtualenvwrapper
     $ mkvirtualenv anitya

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ which files a Bugzilla bug against a package when the upstream project makes a n
 
 Anitya provides a user-friendly interface to add, edit, or browse projects.
 
-:Github page: https://github.com/release-monitoring/anitya
+:Github page: https://github.com/fedora-infra/anitya
 
 User Guide
 ==========

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -11,94 +11,94 @@ API Changes
 -----------
 
 * Filters in APIv2 are now case insensitive
-  (`#807 <https://github.com/release-monitoring/anitya/issues/807>`_)
+  (`#807 <https://github.com/fedora-infra/anitya/issues/807>`_)
 
 
 Features
 --------
 
 * Automatically delete projects without versions that reached configured error threshold
-  (`PR#865 <https://github.com/release-monitoring/anitya/pull/865>`_)
+  (`PR#865 <https://github.com/fedora-infra/anitya/pull/865>`_)
 
 * GitHub: Store and use latest known version cursors
-  (`PR#873 <https://github.com/release-monitoring/anitya/pull/873>`_)
+  (`PR#873 <https://github.com/fedora-infra/anitya/pull/873>`_)
 
 * Link to commit of latest version if known
-  (`PR#874 <https://github.com/release-monitoring/anitya/pull/874>`_)
+  (`PR#874 <https://github.com/fedora-infra/anitya/pull/874>`_)
 
 * Use dropdown field for distro when on Add project form
-  (`#777 <https://github.com/release-monitoring/anitya/issues/777>`_)
+  (`#777 <https://github.com/fedora-infra/anitya/issues/777>`_)
 
 * Add error counter to project
-  (`#829 <https://github.com/release-monitoring/anitya/issues/829>`_)
+  (`#829 <https://github.com/fedora-infra/anitya/issues/829>`_)
 
 * Add timeout option for check service
-  (`#843 <https://github.com/release-monitoring/anitya/issues/843>`_)
+  (`#843 <https://github.com/fedora-infra/anitya/issues/843>`_)
 
 * Strip whitespaces from version when removing prefix
-  (`#866 <https://github.com/release-monitoring/anitya/issues/866>`_)
+  (`#866 <https://github.com/fedora-infra/anitya/issues/866>`_)
 
 
 Bug Fixes
 ---------
 
 * Fix crash on GNU, Crates and Folder backends
-  (`PR#837 <https://github.com/release-monitoring/anitya/pull/837>`_)
+  (`PR#837 <https://github.com/fedora-infra/anitya/pull/837>`_)
 
 * Fix OOM issue with check_service
-  (`PR#842 <https://github.com/release-monitoring/anitya/pull/842>`_)
+  (`PR#842 <https://github.com/fedora-infra/anitya/pull/842>`_)
 
 * Removed duplicate search form from project search result page
-  (`PR#877 <https://github.com/release-monitoring/anitya/pull/877>`_)
+  (`PR#877 <https://github.com/fedora-infra/anitya/pull/877>`_)
 
 * Fix accessing projects in GitLab subgroups
-  (`PR#884 <https://github.com/release-monitoring/anitya/pull/884>`_)
+  (`PR#884 <https://github.com/fedora-infra/anitya/pull/884>`_)
 
 * Database schema image is missing in documentation
-  (`#692 <https://github.com/release-monitoring/anitya/issues/692>`_)
+  (`#692 <https://github.com/fedora-infra/anitya/issues/692>`_)
 
 * Current page is forgotten on login
-  (`#713 <https://github.com/release-monitoring/anitya/issues/713>`_)
+  (`#713 <https://github.com/fedora-infra/anitya/issues/713>`_)
 
 * If URL is changed, update ecosystem value as well
-  (`#764 <https://github.com/release-monitoring/anitya/issues/764>`_)
+  (`#764 <https://github.com/fedora-infra/anitya/issues/764>`_)
 
 * Tooltips are not working on Firefox 68
-  (`#813 <https://github.com/release-monitoring/anitya/issues/813>`_)
+  (`#813 <https://github.com/fedora-infra/anitya/issues/813>`_)
 
 * Use tag name instead of release name for projects, which are checking only releases
-  (`#845 <https://github.com/release-monitoring/anitya/issues/845>`_)
+  (`#845 <https://github.com/fedora-infra/anitya/issues/845>`_)
 
 * Can't disable "Check releases instead of tags" checkbox when editing project
-  (`#855 <https://github.com/release-monitoring/anitya/issues/855>`_)
+  (`#855 <https://github.com/fedora-infra/anitya/issues/855>`_)
 
 * Allow no delimiter in calendar versioning pattern
-  (`#867 <https://github.com/release-monitoring/anitya/issues/867>`_)
+  (`#867 <https://github.com/fedora-infra/anitya/issues/867>`_)
 
 * Distro search is broken
-  (`#876 <https://github.com/release-monitoring/anitya/issues/876>`_)
+  (`#876 <https://github.com/fedora-infra/anitya/issues/876>`_)
 
 
 Development Changes
 -------------------
 
 * Use DEBUG level log for development
-  (`PR#826 <https://github.com/release-monitoring/anitya/pull/826>`_)
+  (`PR#826 <https://github.com/fedora-infra/anitya/pull/826>`_)
 
 * Add Dependabot configuration file
-  (`PR#844 <https://github.com/release-monitoring/anitya/pull/844>`_)
+  (`PR#844 <https://github.com/fedora-infra/anitya/pull/844>`_)
 
 * Bump Vagrant box to Fedora 31
-  (`PR#858 <https://github.com/release-monitoring/anitya/pull/858>`_)
+  (`PR#858 <https://github.com/fedora-infra/anitya/pull/858>`_)
 
 * Mock the Fedora Messaging calls in the unit tests
-  (`PR#860 <https://github.com/release-monitoring/anitya/pull/860>`_)
+  (`PR#860 <https://github.com/fedora-infra/anitya/pull/860>`_)
 
 * Make `black` show diff of needed changes
-  (`PR#878 <https://github.com/release-monitoring/anitya/pull/878>`_)
+  (`PR#878 <https://github.com/fedora-infra/anitya/pull/878>`_)
 
 * Make log output from check_project_release more readable
-  (`#828 <https://github.com/release-monitoring/anitya/issues/828>`_)
+  (`#828 <https://github.com/fedora-infra/anitya/issues/828>`_)
 
 
 Contributors
@@ -120,10 +120,10 @@ Bug Fixes
 ---------
 
 * Fix crash on GNU, Crates and Folder backends
-  (`PR#837 <https://github.com/release-monitoring/anitya/pull/837>`_)
+  (`PR#837 <https://github.com/fedora-infra/anitya/pull/837>`_)
 
 * Fix OOM issue with check_service
-  (`PR#842 <https://github.com/release-monitoring/anitya/pull/842>`_)
+  (`PR#842 <https://github.com/fedora-infra/anitya/pull/842>`_)
 
 
 Contributors
@@ -141,22 +141,22 @@ Bug Fixes
 ---------
 
 * Final info message in check service using error counter instead ratelimit counter
-  (`PR#823 <https://github.com/release-monitoring/anitya/pull/823>`_)
+  (`PR#823 <https://github.com/fedora-infra/anitya/pull/823>`_)
 
 * No error was shown when check_service thread crashed
-  (`PR#824 <https://github.com/release-monitoring/anitya/pull/824>`_)
+  (`PR#824 <https://github.com/fedora-infra/anitya/pull/824>`_)
 
 * Crash when sorting versions with and without date when looking for last retrieved version
-  (`PR#825 <https://github.com/release-monitoring/anitya/pull/825>`_)
+  (`PR#825 <https://github.com/fedora-infra/anitya/pull/825>`_)
 
 * Crash when calling FTP url
-  (`PR#833 <https://github.com/release-monitoring/anitya/pull/833>`_)
+  (`PR#833 <https://github.com/fedora-infra/anitya/pull/833>`_)
 
 * Latest version is not updated when version is removed from web interface
-  (`#830 <https://github.com/release-monitoring/anitya/issues/830>`_)
+  (`#830 <https://github.com/fedora-infra/anitya/issues/830>`_)
 
 * GitHub response 403 doesn't have ratelimit reset time
-  (`#832 <https://github.com/release-monitoring/anitya/issues/832>`_)
+  (`#832 <https://github.com/fedora-infra/anitya/issues/832>`_)
 
 
 Contributors
@@ -174,69 +174,69 @@ Features
 --------
 
 * Adhere to black's Python 3.6 formatting rules
-  (`PR#818 <https://github.com/release-monitoring/anitya/pull/818>`_)
+  (`PR#818 <https://github.com/fedora-infra/anitya/pull/818>`_)
 
 * Support multiple version prefixes
-  (`#655 <https://github.com/release-monitoring/anitya/issues/655>`_)
+  (`#655 <https://github.com/fedora-infra/anitya/issues/655>`_)
 
 * Make libraries.io SSE consumer part of Anitya
-  (`#723 <https://github.com/release-monitoring/anitya/issues/723>`_)
+  (`#723 <https://github.com/fedora-infra/anitya/issues/723>`_)
 
 * Check for new versions only when there is any change on the URL till last version was retrieved
-  (`#730 <https://github.com/release-monitoring/anitya/issues/730>`_)
+  (`#730 <https://github.com/fedora-infra/anitya/issues/730>`_)
 
 * Allow fetching releases on Github backend
-  (`#733 <https://github.com/release-monitoring/anitya/issues/733>`_)
+  (`#733 <https://github.com/fedora-infra/anitya/issues/733>`_)
 
 * Add calendar versioning
-  (`#740 <https://github.com/release-monitoring/anitya/issues/740>`_)
+  (`#740 <https://github.com/fedora-infra/anitya/issues/740>`_)
 
 * Add semantic versioning
-  (`#741 <https://github.com/release-monitoring/anitya/issues/741>`_)
+  (`#741 <https://github.com/fedora-infra/anitya/issues/741>`_)
 
 
 Bug Fixes
 ---------
 
 * Restore missing closing """ in sample configuration
-  (`PR#797 <https://github.com/release-monitoring/anitya/pull/797>`_)
+  (`PR#797 <https://github.com/fedora-infra/anitya/pull/797>`_)
 
 * Constrain failure during alembic downgrade
-  (`PR#812 <https://github.com/release-monitoring/anitya/pull/812>`_)
+  (`PR#812 <https://github.com/fedora-infra/anitya/pull/812>`_)
 
 * Fix createdb.py to now create all tables properly
-  (`PR#817 <https://github.com/release-monitoring/anitya/pull/817>`_)
+  (`PR#817 <https://github.com/fedora-infra/anitya/pull/817>`_)
 
 * Hide ecosystem field for non admin users
-  (`#687 <https://github.com/release-monitoring/anitya/issues/687>`_)
+  (`#687 <https://github.com/fedora-infra/anitya/issues/687>`_)
 
 * Failures during project addition causes distro mapping to be skipped
-  (`#735 <https://github.com/release-monitoring/anitya/issues/735>`_)
+  (`#735 <https://github.com/fedora-infra/anitya/issues/735>`_)
 
 * Handle status code 403 as rate limit exception on Github backend
-  (`#790 <https://github.com/release-monitoring/anitya/issues/790>`_)
+  (`#790 <https://github.com/fedora-infra/anitya/issues/790>`_)
 
 * Cannot add distro
-  (`#791 <https://github.com/release-monitoring/anitya/issues/791>`_)
+  (`#791 <https://github.com/fedora-infra/anitya/issues/791>`_)
 
 * One revision is skipped when doing `alembic upgrade head`
-  (`#819 <https://github.com/release-monitoring/anitya/issues/819>`_)
+  (`#819 <https://github.com/fedora-infra/anitya/issues/819>`_)
 
 
 Development Changes
 -------------------
 
 * Add docker build to Travis CI tests
-  (`PR#799 <https://github.com/release-monitoring/anitya/pull/799>`_)
+  (`PR#799 <https://github.com/fedora-infra/anitya/pull/799>`_)
 
 * Change required version for pyasn1
-  (`PR#812 <https://github.com/release-monitoring/anitya/pull/812>`_)
+  (`PR#812 <https://github.com/fedora-infra/anitya/pull/812>`_)
 
 * Minor packaging cleanup and gitignore additions
-  (`PR#816 <https://github.com/release-monitoring/anitya/pull/816>`_)
+  (`PR#816 <https://github.com/fedora-infra/anitya/pull/816>`_)
 
 * Fix rabbitmq-server in dev environment
-  (`#804 <https://github.com/release-monitoring/anitya/issues/804>`_)
+  (`#804 <https://github.com/fedora-infra/anitya/issues/804>`_)
 
 
 Contributors
@@ -257,14 +257,14 @@ Bug Fixes
 ---------
 
 * Check service: Counters saved to database are always 0
-  (`#795 <https://github.com/release-monitoring/anitya/issues/795>`_)
+  (`#795 <https://github.com/fedora-infra/anitya/issues/795>`_)
 
 
 Development Changes
 -------------------
 
 * Fix issue with documentation build
-  (`#789 <https://github.com/release-monitoring/anitya/issues/789>`_)
+  (`#789 <https://github.com/fedora-infra/anitya/issues/789>`_)
 
 
 Contributors
@@ -282,30 +282,30 @@ Features
 --------
 
 * Turn Anitya cron job to service
-  (`#668 <https://github.com/release-monitoring/anitya/issues/668>`_)
+  (`#668 <https://github.com/fedora-infra/anitya/issues/668>`_)
 
 
 Bug Fixes
 ---------
 
 * Error 500 when opening distro page
-  (`#709 <https://github.com/release-monitoring/anitya/issues/709>`_)
+  (`#709 <https://github.com/fedora-infra/anitya/issues/709>`_)
 
 * "Edit" form for Distro Mapping forgets the distributions
-  (`#744 <https://github.com/release-monitoring/anitya/issues/744>`_)
+  (`#744 <https://github.com/fedora-infra/anitya/issues/744>`_)
 
 * anitya.project.map.new not send when adding new mapping through APIv2
-  (`#760 <https://github.com/release-monitoring/anitya/issues/760>`_)
+  (`#760 <https://github.com/fedora-infra/anitya/issues/760>`_)
 
 
 Development Changes
 -------------------
 
 * Add new dependency ordered_set
-  (`#668 <https://github.com/release-monitoring/anitya/issues/668>`_)
+  (`#668 <https://github.com/fedora-infra/anitya/issues/668>`_)
 
 * Add diff-cover to tox testing suite
-  (`#782 <https://github.com/release-monitoring/anitya/issues/782>`_)
+  (`#782 <https://github.com/fedora-infra/anitya/issues/782>`_)
 
 
 Contributors
@@ -323,24 +323,24 @@ Bug Fixes
 ---------
 
 * Fix topic for fedora_messaging
-  (`PR#750 <https://github.com/release-monitoring/anitya/pull/750>`_)
+  (`PR#750 <https://github.com/fedora-infra/anitya/pull/750>`_)
 
 
 Development Changes
 -------------------
 
 * Check formatting using black
-  (`PR#725 <https://github.com/release-monitoring/anitya/pull/725>`_)
+  (`PR#725 <https://github.com/fedora-infra/anitya/pull/725>`_)
 
 * Remove gunicorn dependency
-  (`PR#742 <https://github.com/release-monitoring/anitya/pull/742>`_)
+  (`PR#742 <https://github.com/fedora-infra/anitya/pull/742>`_)
 
 
 Other Changes
 -------------
 
 * Add sample configuration for Fedora Messaging
-  (`#738 <https://github.com/release-monitoring/anitya/issues/738>`_)
+  (`#738 <https://github.com/fedora-infra/anitya/issues/738>`_)
 
 
 Contributors
@@ -358,42 +358,42 @@ Features
 --------
 
 * Convert to Fedora Messaging
-  (`PR#570 <https://github.com/release-monitoring/anitya/pull/570>`_)
+  (`PR#570 <https://github.com/fedora-infra/anitya/pull/570>`_)
 
 
 Bug Fixes
 ---------
 
 * Release notes point to fedora-messaging
-  (`#699 <https://github.com/release-monitoring/anitya/issues/699>`_)
+  (`#699 <https://github.com/fedora-infra/anitya/issues/699>`_)
 
 * Javascript error on add project page
-  (`#714 <https://github.com/release-monitoring/anitya/issues/714>`_)
+  (`#714 <https://github.com/fedora-infra/anitya/issues/714>`_)
 
 * Changed copyright datum on frontpage to 2013-2019
-  (`#721 <https://github.com/release-monitoring/anitya/issues/721>`_)
+  (`#721 <https://github.com/fedora-infra/anitya/issues/721>`_)
 
 * Invalid User-Agent
-  (`#729 <https://github.com/release-monitoring/anitya/issues/729>`_)
+  (`#729 <https://github.com/fedora-infra/anitya/issues/729>`_)
 
 Development Changes
 -------------------
 
 * Rename Vagrantfile.example to Vagrantfile
-  (`PR#715 <https://github.com/release-monitoring/anitya/pull/715>`_)
+  (`PR#715 <https://github.com/fedora-infra/anitya/pull/715>`_)
 
 * Introduce bandit to tox tests
-  (`PR#724 <https://github.com/release-monitoring/anitya/pull/724>`_)
+  (`PR#724 <https://github.com/fedora-infra/anitya/pull/724>`_)
 
 
 Other Changes
 -------------
 
 * Added example of usage in contribution guide.
-  (`PR#719 <https://github.com/release-monitoring/anitya/pull/719>`_)
+  (`PR#719 <https://github.com/fedora-infra/anitya/pull/719>`_)
 
 * Fix URL to fedmsg website on index.html to use the correct website URL
-  (`PR#722 <https://github.com/release-monitoring/anitya/pull/722>`_)
+  (`PR#722 <https://github.com/fedora-infra/anitya/pull/722>`_)
 
 
 Contributors
@@ -416,27 +416,27 @@ Features
 --------
 
 * Show raw version on project page for admins
-  (`PR#696 <https://github.com/release-monitoring/anitya/pull/696>`_)
+  (`PR#696 <https://github.com/fedora-infra/anitya/pull/696>`_)
 
 
 Bug Fixes
 ---------
 
 * Libraries.io consumer is replacing topic_prefix for Anitya
-  (`PR#704 <https://github.com/release-monitoring/anitya/pull/704>`_)
+  (`PR#704 <https://github.com/fedora-infra/anitya/pull/704>`_)
 
 * Release unlocked lock in cronjob
-  (`PR#708 <https://github.com/release-monitoring/anitya/pull/708>`_)
+  (`PR#708 <https://github.com/fedora-infra/anitya/pull/708>`_)
 
 * Comparing by dates created version duplicates
-  (`#702 <https://github.com/release-monitoring/anitya/issues/702>`_)
+  (`#702 <https://github.com/fedora-infra/anitya/issues/702>`_)
 
 
 Development Changes
 -------------------
 
 * Remove Date version scheme
-  (`PR#707 <https://github.com/release-monitoring/anitya/pull/707>`_)
+  (`PR#707 <https://github.com/fedora-infra/anitya/pull/707>`_)
 
 
 Contributors
@@ -455,91 +455,91 @@ Features
 --------
 
 * Add delete cascade on DB models
-  (`PR#608 <https://github.com/release-monitoring/anitya/pull/608>`_)
+  (`PR#608 <https://github.com/fedora-infra/anitya/pull/608>`_)
 
 * Logs table is replaced by simple status on project
-  (`PR#635 <https://github.com/release-monitoring/anitya/pull/635>`_)
+  (`PR#635 <https://github.com/fedora-infra/anitya/pull/635>`_)
 
 * Update form for adding new distributions
-  (`PR#639 <https://github.com/release-monitoring/anitya/pull/639>`_)
+  (`PR#639 <https://github.com/fedora-infra/anitya/pull/639>`_)
 
 * Refresh page after full check
-  (`PR#670 <https://github.com/release-monitoring/anitya/pull/670>`_)
+  (`PR#670 <https://github.com/fedora-infra/anitya/pull/670>`_)
 
 * Show URL for version check on project UI
-  (`#549 <https://github.com/release-monitoring/anitya/issues/549>`_)
+  (`#549 <https://github.com/fedora-infra/anitya/issues/549>`_)
 
 * Link to backend info from project view and edit pages
-  (`#556 <https://github.com/release-monitoring/anitya/issues/556>`_)
+  (`#556 <https://github.com/fedora-infra/anitya/issues/556>`_)
 
 * Retrieve all versions, not only the newest one
-  (`#595 <https://github.com/release-monitoring/anitya/issues/595>`_)
+  (`#595 <https://github.com/fedora-infra/anitya/issues/595>`_)
 
 * Add rate limit handling
-  (`#600 <https://github.com/release-monitoring/anitya/issues/600>`_)
+  (`#600 <https://github.com/fedora-infra/anitya/issues/600>`_)
 
 * Basic user management UI for admins
-  (`#621 <https://github.com/release-monitoring/anitya/issues/621>`_)
+  (`#621 <https://github.com/fedora-infra/anitya/issues/621>`_)
 
 * Rate limit enhancements
-  (`#665 <https://github.com/release-monitoring/anitya/issues/665>`_)
+  (`#665 <https://github.com/fedora-infra/anitya/issues/665>`_)
 
 * Add ecosystem information to project.version.update fedmsg topic.
-  (`#666 <https://github.com/release-monitoring/anitya/issues/666>`_)
+  (`#666 <https://github.com/fedora-infra/anitya/issues/666>`_)
 
 
 Bug Fixes
 ---------
 
 * Fix unhandled exception in GitLab backend
-  (`PR#663 <https://github.com/release-monitoring/anitya/pull/663>`_)
+  (`PR#663 <https://github.com/fedora-infra/anitya/pull/663>`_)
 
 * Can't rename mapping for gstreamer
-  (`#598 <https://github.com/release-monitoring/anitya/issues/598>`_)
+  (`#598 <https://github.com/fedora-infra/anitya/issues/598>`_)
 
 * Source map error: request failed with status 404 for various javascript packages
-  (`#606 <https://github.com/release-monitoring/anitya/issues/606>`_)
+  (`#606 <https://github.com/fedora-infra/anitya/issues/606>`_)
 
 * about#test-your-regex link is broken
-  (`#628 <https://github.com/release-monitoring/anitya/issues/628>`_)
+  (`#628 <https://github.com/fedora-infra/anitya/issues/628>`_)
 
 * Github backend returns reversed list
-  (`#642 <https://github.com/release-monitoring/anitya/issues/642>`_)
+  (`#642 <https://github.com/fedora-infra/anitya/issues/642>`_)
 
 * Version prefix not working in GitLab backend
-  (`#644 <https://github.com/release-monitoring/anitya/issues/644>`_)
+  (`#644 <https://github.com/fedora-infra/anitya/issues/644>`_)
 
 * Latest version on Project UI is shown with prefix
-  (`#662 <https://github.com/release-monitoring/anitya/issues/662>`_)
+  (`#662 <https://github.com/fedora-infra/anitya/issues/662>`_)
 
 * Crash when version is too long
-  (`#674 <https://github.com/release-monitoring/anitya/issues/674>`_)
+  (`#674 <https://github.com/fedora-infra/anitya/issues/674>`_)
 
 
 Development Changes
 -------------------
 
 * Add python 3.7 to tox tests
-  (`PR#650 <https://github.com/release-monitoring/anitya/pull/650>`_)
+  (`PR#650 <https://github.com/fedora-infra/anitya/pull/650>`_)
 
 * Update Vagrantfile to use Fedora 29 image
-  (`PR#653 <https://github.com/release-monitoring/anitya/pull/653>`_)
+  (`PR#653 <https://github.com/fedora-infra/anitya/pull/653>`_)
 
 * Drop support for python 2.7 and python 3.5
-  (`PR#672 <https://github.com/release-monitoring/anitya/pull/672>`_)
+  (`PR#672 <https://github.com/fedora-infra/anitya/pull/672>`_)
 
 
 Other Changes
 -------------
 
 * Update contribution guide
-  (`PR#636 <https://github.com/release-monitoring/anitya/pull/636>`_)
+  (`PR#636 <https://github.com/fedora-infra/anitya/pull/636>`_)
 
 * Add GDPR SAR script
-  (`PR#649 <https://github.com/release-monitoring/anitya/pull/649>`_)
+  (`PR#649 <https://github.com/fedora-infra/anitya/pull/649>`_)
 
 * Add supported versions of python to setup script
-  (`PR#651 <https://github.com/release-monitoring/anitya/pull/651>`_)
+  (`PR#651 <https://github.com/fedora-infra/anitya/pull/651>`_)
 
 
 Contributors
@@ -560,33 +560,33 @@ Features
 --------
 
 * Show users their ID on Settings page
-  (`PR#631 <https://github.com/release-monitoring/anitya/pull/631>`_)
+  (`PR#631 <https://github.com/fedora-infra/anitya/pull/631>`_)
 
 * Add sorting by creation date for versions
-  (`#593 <https://github.com/release-monitoring/anitya/issues/593>`_)
+  (`#593 <https://github.com/fedora-infra/anitya/issues/593>`_)
 
 
 Bug Fixes
 ---------
 
 * Can't parse owner/repo on Github backend
-  (`PR#632 <https://github.com/release-monitoring/anitya/pull/632>`_)
+  (`PR#632 <https://github.com/fedora-infra/anitya/pull/632>`_)
 
 * Login into staging using OpenID not possible
-  (`#616 <https://github.com/release-monitoring/anitya/issues/616>`_)
+  (`#616 <https://github.com/fedora-infra/anitya/issues/616>`_)
 
 
 Development Changes
 -------------------
 
 * Add towncrier for generating release notes
-  (`PR#618 <https://github.com/release-monitoring/anitya/pull/618>`_)
+  (`PR#618 <https://github.com/fedora-infra/anitya/pull/618>`_)
 
 * Remove deprecations warning
-  (`PR#627 <https://github.com/release-monitoring/anitya/pull/627>`_)
+  (`PR#627 <https://github.com/fedora-infra/anitya/pull/627>`_)
 
 * Add documentation dependency to vagrant container
-  (`PR#630 <https://github.com/release-monitoring/anitya/pull/630>`_)
+  (`PR#630 <https://github.com/fedora-infra/anitya/pull/630>`_)
 
 
 Contributors
@@ -606,13 +606,13 @@ Features
 --------
 
 * Add database schema generation (`#603
-  <https://github.com/release-monitoring/anitya/pull/603>`_).
+  <https://github.com/fedora-infra/anitya/pull/603>`_).
 
 Bug Fixes
 ---------
 
 * Fix cron issues (`#613
-  <https://github.com/release-monitoring/anitya/pull/613>`_).
+  <https://github.com/fedora-infra/anitya/pull/613>`_).
 
 v0.13.0
 =======
@@ -627,29 +627,29 @@ Features
 
 * Update GitHub backend to `GitHub API v4
   <https://developer.github.com/v4/>`_ (`#582
-  <https://github.com/release-monitoring/anitya/pull/582>`_).
+  <https://github.com/fedora-infra/anitya/pull/582>`_).
 
 * Add GitLab backend. This is implemented using `GitLab API v4
   <https://docs.gitlab.com/ee/api/README.html>`_ (`#591
-  <https://github.com/release-monitoring/anitya/pull/591>`_).
+  <https://github.com/fedora-infra/anitya/pull/591>`_).
 
 * Update CPAN backend to use metacpan.org (`#569
-  <https://github.com/release-monitoring/anitya/pull/569>`_).
+  <https://github.com/fedora-infra/anitya/pull/569>`_).
 
 * Parse XML from CPAN with defusedxml (`#569
-  <https://github.com/release-monitoring/anitya/pull/569>`_).
+  <https://github.com/fedora-infra/anitya/pull/569>`_).
 
 Bug Fixes
 ---------
 
 * Change edit message for project, when no edit actually happened (`#579
-  <https://github.com/release-monitoring/anitya/pull/579>`_).
+  <https://github.com/fedora-infra/anitya/pull/579>`_).
 
 * Fix wrong title on Edit page (`#578
-  <https://github.com/release-monitoring/anitya/pull/578>`_).
+  <https://github.com/fedora-infra/anitya/pull/578>`_).
 
 * Default custom regex is now configurable (`#571
-  <https://github.com/release-monitoring/anitya/pull/571>`_).
+  <https://github.com/fedora-infra/anitya/pull/571>`_).
 
 v0.12.1
 =======
@@ -659,7 +659,7 @@ Dependencies
 
 * Unpin ``straight.plugin`` dependency. It was pinned to avoid a bug which has
   since been fixed in the latest releases (`#564
-  <https://github.com/release-monitoring/anitya/pull/564>`_).
+  <https://github.com/fedora-infra/anitya/pull/564>`_).
 
 Bug Fixes
 ---------
@@ -668,7 +668,7 @@ Bug Fixes
   identity providers using the same email, return a HTTP 400 to indicate the
   client should not retry the request and inform them they must log in with
   the original identity provider (`#563
-  <https://github.com/release-monitoring/anitya/pull/563>`_).
+  <https://github.com/fedora-infra/anitya/pull/563>`_).
 
 
 v0.12.0
@@ -703,7 +703,7 @@ APIs
 ^^^^
 
 A number of functions that make up Anitya's Python API have been moved
-(`#503 <https://github.com/release-monitoring/anitya/pull/503>`_). The full
+(`#503 <https://github.com/fedora-infra/anitya/pull/503>`_). The full
 list of functions are below. Note that no function signatures have changed.
 
 * ``anitya.check_release`` is now ``anitya.lib.utilities.check_project_release``.

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -247,7 +247,7 @@ freenode network. Please do stop by and say hello.
 .. _GitHub: https://github.com/
 .. _PyPI: https://pypi.python.org/
 .. _re: https://docs.python.org/3/library/re.html
-.. _issue tracker: https://github.com/release-monitoring/anitya/issues
-.. _source code: https://github.com/release-monitoring/anitya
+.. _issue tracker: https://github.com/fedora-infra/anitya/issues
+.. _source code: https://github.com/fedora-infra/anitya
 .. _fedmsg topic documentation:
     https://fedora-fedmsg.readthedocs.io/en/latest/topics.html#anitya

--- a/news/PR887.dev
+++ b/news/PR887.dev
@@ -1,0 +1,1 @@
+Move Anitya from release-monitoring organization to fedora-infra

--- a/news/_template.rst
+++ b/news/_template.rst
@@ -1,10 +1,10 @@
 {% macro issue_url(value) -%}
    {%- if value.startswith("PR") -%}
-     `PR#{{ value[2:] }} <https://github.com/release-monitoring/anitya/pull/{{ value[2:] }}>`_
+     `PR#{{ value[2:] }} <https://github.com/fedora-infra/anitya/pull/{{ value[2:] }}>`_
    {%- elif value.startswith("C") -%}
-     `{{ value[1:] }} <https://github.com/release-monitoring/anitya/commit/{{ value[1:] }}>`_
+     `{{ value[1:] }} <https://github.com/fedora-infra/anitya/commit/{{ value[1:] }}>`_
    {%- else -%}
-     `#{{ value }} <https://github.com/release-monitoring/anitya/issues/{{ value }}>`_
+     `#{{ value }} <https://github.com/fedora-infra/anitya/issues/{{ value }}>`_
    {%- endif -%}
 {%- endmacro -%}
 


### PR DESCRIPTION
Anitya was one of the applications that was in the different
organization than rest of the application maintained by Fedora
Infrastructure team. To make our work more consistent it was decided to
move it to fedora-infra organization.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>