### PR TITLE
GitHub backend: do not raise error if no new upstream version

### DIFF
--- a/anitya/lib/backends/github.py
+++ b/anitya/lib/backends/github.py
@@ -195,7 +195,7 @@ class GithubBackend(BaseBackend):
             project.latest_version_cursor = None
             versions = cls._retrieve_versions(owner, repo, project)
 
-        if len(versions) == 0:
+        if len(versions) == 0 and project.latest_version_cursor is None:
             raise AnityaPluginException(
                 "%s: No upstream version found." % (project.name)
             )

--- a/news/892.bug
+++ b/news/892.bug
@@ -1,0 +1,1 @@
+GitHub backend: Failure with error "No upstream version found" when the project has no new version


### PR DESCRIPTION
For GitHub backend, Anitya throws an error and fails with "No upstream version found" if there's no new version. However, it should throw an error only if it cannot fetch versions, or if there's no version at all, but not when there's no new version because of the cursor.

Fix #892