### PR TITLE
Fix broken links to fedmsg.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Anitya
 Anitya is a release monitoring project. It provides a user-friendly interface
 to add, edit, or browse projects. A cron job can be configured to regularly
 scan for new releases of projects. When Anitya discovers a new release for a
-project, it publishes a ZeroMQ message via `fedmsg <http://fedmsg.com>`_.
+project, it publishes a ZeroMQ message via `fedmsg`_.
 This makes it easy to integrate with Anitya and perform actions when a new
 release is created for a project. For example, the Fedora project runs a service
 called `the-new-hotness <https://github.com/fedora-infra/the-new-hotness/>`_
@@ -50,3 +50,4 @@ For details on how to contribute, check out the `contribution guide`_.
 
 .. _documentation: https://anitya.readthedocs.io/
 .. _contribution guide: https://anitya.readthedocs.io/en/latest/contributing.html
+.. _fedmsg: http://web.archive.org/web/20170625121632/http://www.fedmsg.com/en/latest/

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -199,7 +199,7 @@ default to using the global configuration.
 To display the messages, we turn off signature validation (since the local
 server will be emitting unsigned messages) and pretty-print the received JSON.
 
-Refer to the `fedmsg consumer API <http://www.fedmsg.com/en/latest/consuming/>`_
+Refer to the `fedmsg subscription API`_
 for more details on receiving event messages programmatically.
 
 
@@ -285,3 +285,4 @@ If you are a maintainer and wish to make a release of Anitya fedora messaging sc
 
 .. _Ansible: https://www.ansible.com/
 .. _Vagrant: https://vagrantup.com/
+.. _fedmsg subscription API: https://fedmsg.readthedocs.io/en/latest/subscribing/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,8 @@ Anitya is a release monitoring project.
 
 Its goal is to regularly check if a project has made a new release.
 When Anitya discovers a new release for a project, it publishes a ZeroMQ message via
-`fedmsg <http://fedmsg.com>`_. This makes it easy to integrate with Anitya and perform
+`fedmsg <http://web.archive.org/web/20170625121632/http://www.fedmsg.com/en/latest/>`_.
+This makes it easy to integrate with Anitya and perform
 actions when a new release is created for a project. For example, the Fedora project
 runs a service called `the-new-hotness <https://github.com/fedora-infra/the-new-hotness/>`_
 which files a Bugzilla bug against a package when the upstream project makes a new release.

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -181,7 +181,7 @@ Integrating with Anitya
 fedmsg
 ------
 
-`fedmsg <http://www.fedmsg.com>`_ is a message bus. In other words it is a
+`fedmsg`_ is a message bus. In other words it is a
 system that allows for the sending and receiving of notifications between
 applications.  For anitya, every action made on the application is
 announced/broadcasted on this bus, allowing anyone listening to it to act
@@ -189,7 +189,7 @@ immediately instead of (for example) polling hourly all the data, looking for
 changes, and acting then. For the full list of messages Anitya sends, see
 the `fedmsg topic documentation`_.
 
-To start receiving `fedmsg <http://www.fedmsg.com>`_ messages from anitya,
+To start receiving `fedmsg`_ messages from anitya,
 it is as simple as:
 
 * install ``fedmsg`` the way you want:
@@ -249,5 +249,6 @@ freenode network. Please do stop by and say hello.
 .. _re: https://docs.python.org/3/library/re.html
 .. _issue tracker: https://github.com/fedora-infra/anitya/issues
 .. _source code: https://github.com/fedora-infra/anitya
+.. _fedmsg: http://web.archive.org/web/20170625121632/http://www.fedmsg.com/en/latest/
 .. _fedmsg topic documentation:
     https://fedora-fedmsg.readthedocs.io/en/latest/topics.html#anitya


### PR DESCRIPTION
See https://github.com/fedora-infra/fedmsg/issues/524

I left link to web archive in few places, because it contains better introduction for newcomers than this text from current RTD site.

> fedmsg (Federated Message Bus) is a library built on ZeroMQ using the PyZMQ Python bindings. fedmsg aims to make it easy to connect services together using ZeroMQ publishers and subscribers.