### PR TITLE
Remove social_auth info from SAR script

### DIFF
--- a/anitya/db/models.py
+++ b/anitya/db/models.py
@@ -995,22 +995,12 @@ class User(Base):
         Returns:
             dict: `User` object transformed to dictionary.
         """
-        social_auth = []
-        for soc_auth in self.social_auth.all():
-            social_auth.append(
-                dict(
-                    provider=soc_auth.provider,
-                    extra_data=soc_auth.extra_data,
-                    uid=soc_auth.uid,
-                )
-            )
 
         return dict(
             id=str(self.id),
             email=self.email,
             username=self.username,
             active=self.active,
-            social_auth=social_auth,
         )
 
 

--- a/anitya/sar.py
+++ b/anitya/sar.py
@@ -46,7 +46,6 @@ def main():
     Retrieve database entry for user.
     """
     db.initialize(config)
-    _log.setLevel(logging.DEBUG)
     sar_username = os.getenv("SAR_USERNAME")
     sar_email = os.getenv("SAR_EMAIL")
 
@@ -68,6 +67,6 @@ def main():
 
 
 if __name__ == "__main__":
-    _log.info("SAR script start")
+    _log.debug("SAR script start")
     main()
-    _log.info("SAR script end")
+    _log.debug("SAR script end")

--- a/anitya/tests/db/test_models.py
+++ b/anitya/tests/db/test_models.py
@@ -1157,11 +1157,6 @@ class UserTests(DatabaseTestCase):
     def test_to_dict(self):
         """ Assert the correct dictionary is returned. """
         user = models.User(email="user@fedoraproject.org", username="user")
-        user_social_auth = social_models.UserSocialAuth(
-            user_id=user.id, user=user, provider="FAS"
-        )
-        user_social_auth.set_extra_data({"wookie": "too hairy"})
-        self.session.add(user_social_auth)
         self.session.add(user)
         self.session.commit()
 
@@ -1170,13 +1165,6 @@ class UserTests(DatabaseTestCase):
             "email": user.email,
             "username": user.username,
             "active": user.active,
-            "social_auth": [
-                {
-                    "provider": user_social_auth.provider,
-                    "extra_data": user_social_auth.extra_data,
-                    "uid": user_social_auth.uid,
-                }
-            ],
         }
 
         json = user.to_dict()

--- a/anitya/tests/test_sar.py
+++ b/anitya/tests/test_sar.py
@@ -27,8 +27,6 @@ import pytest
 import mock
 import json
 
-from social_flask_sqlalchemy import models as social_models
-
 import anitya.sar as sar
 from anitya.db import models
 from anitya.tests.base import DatabaseTestCase
@@ -49,15 +47,11 @@ class SARTests(DatabaseTestCase):
         e-mail.
         """
         user = models.User(email="user@fedoraproject.org", username="user", active=True)
-        user_social_auth = social_models.UserSocialAuth(user_id=user.id, user=user)
 
-        self.session.add(user_social_auth)
         self.session.add(user)
 
         user2 = models.User(email="user2@email.org", username="user2", active=True)
-        user_social_auth = social_models.UserSocialAuth(user_id=user2.id, user=user2)
 
-        self.session.add(user_social_auth)
         self.session.add(user2)
         self.session.commit()
 
@@ -67,7 +61,6 @@ class SARTests(DatabaseTestCase):
                 "username": user.username,
                 "email": user.email,
                 "active": user.active,
-                "social_auth": [{"uid": None, "provider": None, "extra_data": None}],
             }
         ]
 
@@ -86,15 +79,11 @@ class SARTests(DatabaseTestCase):
         username.
         """
         user = models.User(email="user@fedoraproject.org", username="user", active=True)
-        user_social_auth = social_models.UserSocialAuth(user_id=user.id, user=user)
 
-        self.session.add(user_social_auth)
         self.session.add(user)
 
         user2 = models.User(email="user2@email.org", username="user2", active=True)
-        user_social_auth = social_models.UserSocialAuth(user_id=user2.id, user=user2)
 
-        self.session.add(user_social_auth)
         self.session.add(user2)
         self.session.commit()
 
@@ -104,7 +93,6 @@ class SARTests(DatabaseTestCase):
                 "username": user.username,
                 "email": user.email,
                 "active": user.active,
-                "social_auth": [{"uid": None, "provider": None, "extra_data": None}],
             }
         ]
 
@@ -121,15 +109,11 @@ class SARTests(DatabaseTestCase):
         Assert that correct user data are dumped when nothing is provided.
         """
         user = models.User(email="user@fedoraproject.org", username="user", active=True)
-        user_social_auth = social_models.UserSocialAuth(user_id=user.id, user=user)
 
-        self.session.add(user_social_auth)
         self.session.add(user)
 
         user2 = models.User(email="user2@email.org", username="user2", active=True)
-        user_social_auth = social_models.UserSocialAuth(user_id=user2.id, user=user2)
 
-        self.session.add(user_social_auth)
         self.session.add(user2)
         self.session.commit()
 

--- a/news/954.bug
+++ b/news/954.bug
@@ -1,0 +1,1 @@
+sar.py fails with AttributeError: 'User' object has no attribute 'social_auth'


### PR DESCRIPTION
To fix #954 I decided to remove social auth info from SAR script. Only
useful information provided was the list of providers the user was
authenticated with.

The info from the SAR script now contains id of the user, mail and if
the account is active or not.

Fixes #954.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>