### PR TITLE
Implement fedmsg_meta_methods

### DIFF
--- a/anitya_schema/anitya_schema/distro_messages.py
+++ b/anitya_schema/anitya_schema/distro_messages.py
@@ -17,6 +17,8 @@
 
 from fedora_messaging import message
 
+ANITYA_URL = "https://release-monitoring.org/"
+
 
 class DistroCreated(message.Message):
     """
@@ -69,6 +71,11 @@ class DistroCreated(message.Message):
     def distro_name(self):
         """The new distribution's name."""
         return self.body["distro"]["name"]
+
+    @property
+    def distro_url(self):
+        """The new distribution url."""
+        return ANITYA_URL + "distros/" + self.distro_name
 
 
 class DistroEdited(message.Message):
@@ -133,9 +140,19 @@ class DistroEdited(message.Message):
         return self.body["message"]["new"]
 
     @property
+    def distro_url_new(self):
+        """The distribution's new url."""
+        return ANITYA_URL + "distros/" + self.distro_name_new
+
+    @property
     def distro_name_old(self):
         """The distribution's old name."""
         return self.body["message"]["old"]
+
+    @property
+    def distro_url_old(self):
+        """The distribution's old url."""
+        return ANITYA_URL + "distros/" + self.distro_name_old
 
 
 class DistroDeleted(message.Message):
@@ -192,3 +209,8 @@ class DistroDeleted(message.Message):
     def distro_name(self):
         """The new distribution's name."""
         return self.body["distro"]["name"]
+
+    @property
+    def distro_url(self):
+        """The new distribution url."""
+        return ANITYA_URL + "distros/" + self.distro_name

--- a/anitya_schema/anitya_schema/project_messages.py
+++ b/anitya_schema/anitya_schema/project_messages.py
@@ -17,6 +17,8 @@
 
 from fedora_messaging import message
 
+ANITYA_URL = "https://release-monitoring.org/"
+
 
 class ProjectMessage(message.Message):
     """
@@ -90,6 +92,11 @@ class ProjectMessage(message.Message):
         """The versions associated with the project."""
         return self.body["project"]["versions"]
 
+    @property
+    def project_url(self):
+        """The project url in Anitya."""
+        return ANITYA_URL + "projects/" + str(self.project_id) + "/"
+
 
 class ProjectCreated(ProjectMessage):
     """The message sent when a new project is created in Anitya."""
@@ -142,7 +149,7 @@ class ProjectEdited(ProjectMessage):
     body_schema = {
         "id": "https://fedoraproject.org/jsonschema/anitya_project_createdv1.json",
         "$schema": "http://json-schema.org/draft-04/schema#",
-        "description": "Message sent when a new project is created in Anitya",
+        "description": "Message sent when a project is edited in Anitya",
         "type": "object",
         "required": ["project", "message", "distro"],
         "properties": {
@@ -151,9 +158,17 @@ class ProjectEdited(ProjectMessage):
                 "type": "object",
                 "properties": {
                     "agent": {"type": "string"},
+                    "changes": {
+                        "type": "object",
+                        "properties": {
+                            "new": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                            "old": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                        },
+                    },
+                    "fields": {"type": "array", "items": {"type": "string"}},
                     "project": {"type": "string"},
                 },
-                "required": ["agent", "project"],
+                "required": ["agent", "project", "changes", "fields"],
             },
             "project": ProjectMessage.project_schema,
         },
@@ -283,6 +298,11 @@ class ProjectFlag(ProjectMessage):
         return self.body["message"]["packages"]
 
     @property
+    def flag_url(self):
+        """The anitya url for the flag."""
+        return ANITYA_URL + "flags/"
+
+    @property
     def reason(self):
         """Reason for the flag creation."""
         return self.body["message"]["reason"]
@@ -333,6 +353,11 @@ class ProjectFlagSet(message.Message):
     def flag(self):
         """The id of the flag."""
         return self.body["message"]["flag"]
+
+    @property
+    def flag_url(self):
+        """The anitya url for the flag."""
+        return ANITYA_URL + "flags/"
 
     @property
     def state(self):

--- a/anitya_schema/anitya_schema/tests/test_distro_messages.py
+++ b/anitya_schema/anitya_schema/tests/test_distro_messages.py
@@ -61,6 +61,14 @@ class TestDistroCreated(unittest.TestCase):
 
         self.assertEqual(self.message.distro_name, "Dummy")
 
+    def test_distro_url(self):
+        """ Assert that distro url is returned. """
+        self.message.body = {"distro": {"name": "Dummy"}}
+
+        self.assertEqual(
+            self.message.distro_url, "https://release-monitoring.org/distros/Dummy"
+        )
+
 
 class TestDistroEdited(unittest.TestCase):
     """ Tests for anitya_schema.distro_messages.DistroEdited class. """
@@ -107,11 +115,27 @@ class TestDistroEdited(unittest.TestCase):
 
         self.assertEqual(self.message.distro_name_new, "Dummy")
 
+    def test_url_new(self):
+        """ Assert that correct anitya url is returned. """
+        self.message.body = {"message": {"new": "Dummy"}}
+
+        self.assertEqual(
+            self.message.distro_url_new, "https://release-monitoring.org/distros/Dummy"
+        )
+
     def test_name_old(self):
         """ Assert that old_name string is returned. """
         self.message.body = {"message": {"old": "Dummy"}}
 
         self.assertEqual(self.message.distro_name_old, "Dummy")
+
+    def test_url_old(self):
+        """ Assert that correct anitya url is returned. """
+        self.message.body = {"message": {"old": "Dummy"}}
+
+        self.assertEqual(
+            self.message.distro_url_old, "https://release-monitoring.org/distros/Dummy"
+        )
 
 
 class TestDistroDeleted(unittest.TestCase):
@@ -153,3 +177,11 @@ class TestDistroDeleted(unittest.TestCase):
         self.message.body = {"distro": {"name": "Dummy"}}
 
         self.assertEqual(self.message.distro_name, "Dummy")
+
+    def test_distro_url(self):
+        """ Assert that distro url is returned. """
+        self.message.body = {"distro": {"name": "Dummy"}}
+
+        self.assertEqual(
+            self.message.distro_url, "https://release-monitoring.org/distros/Dummy"
+        )

--- a/anitya_schema/anitya_schema/tests/test_project_messages.py
+++ b/anitya_schema/anitya_schema/tests/test_project_messages.py
@@ -83,6 +83,13 @@ class TestProjectMessage(unittest.TestCase):
 
         self.assertEqual(self.message.project_versions, ["1.00", "0.99"])
 
+    def test_project_url(self):
+        """Assert that correct url to Anitya is returned."""
+        self.message.body = {"project": {"id": 0}}
+        self.assertEqual(
+            self.message.project_url, "https://release-monitoring.org/projects/0/"
+        )
+
 
 class TestProjectCreated(unittest.TestCase):
     """Tests for anitya_schema.project_messages.ProjectCreated class."""
@@ -241,6 +248,10 @@ class TestProjectFlag(unittest.TestCase):
 
         self.assertEqual(self.message.mappings, exp)
 
+    def test_flag_url(self):
+        """ Assert that correct url is returned. """
+        self.assertEqual(self.message.flag_url, "https://release-monitoring.org/flags/")
+
     def test_reason(self):
         """Assert that reason is returned."""
         self.message.body = {"message": {"reason": "Dummy"}}
@@ -292,6 +303,10 @@ class TestProjectFlagSet(unittest.TestCase):
         self.message.body = {"message": {"flag": "Dummy"}}
 
         self.assertEqual(self.message.flag, "Dummy")
+
+    def test_flag_url(self):
+        """ Assert that correct url is returned. """
+        self.assertEqual(self.message.flag_url, "https://release-monitoring.org/flags/")
 
     def test_state(self):
         """ Assert that state string is returned. """

--- a/news/752.feature
+++ b/news/752.feature
@@ -1,0 +1,1 @@
+Implement fedmsg meta methods in fedora messaging schema


### PR DESCRIPTION
This commit implements missing fedmsg_meta_methods. There are still few
exceptions that are not implemented.

* username - this connects to FAS which is something I don't want the
  schema to do. It shouldn't connect to any external system, this should
  be left on consumer

What is implemented:

* Anitya url for various components to have direct url in Anitya for
  these components
* List of packages in messages

Closes #752

Signed-off-by: Michal Konečný <mkonecny@redhat.com>