### PR TITLE
Add preview mode

### DIFF
--- a/anitya/app.py
+++ b/anitya/app.py
@@ -73,8 +73,15 @@ def create(config=None):
 
     # Register the v2 API resources
     app.api = Api(app)
-    app.api.add_resource(api_v2.ProjectsResource, "/api/v2/projects/")
-    app.api.add_resource(api_v2.PackagesResource, "/api/v2/packages/")
+    app.api.add_resource(
+        api_v2.ProjectsResource, "/api/v2/projects/", endpoint="apiv2.projects"
+    )
+    app.api.add_resource(
+        api_v2.PackagesResource, "/api/v2/packages/", endpoint="apiv2.packages"
+    )
+    app.api.add_resource(
+        api_v2.VersionsResource, "/api/v2/versions/", endpoint="apiv2.versions"
+    )
 
     # Register all the view blueprints
     app.register_blueprint(ui.ui_blueprint)

--- a/anitya/templates/project.html
+++ b/anitya/templates/project.html
@@ -347,11 +347,9 @@
     }
     $(btn).hide(); $(btn + "-spinner").show();
     var _id = "{{ project.id }}";
-    var _url = "{{ url_for('anitya_apiv1.api_get_version') }}";
+    var _url = "{{ url_for('apiv2.versions')}}";
     data = {id: _id};
-    if (test) {
-        data.test = test;
-    }
+    data.dry_run = test;
     $.ajax({
         url: _url ,
         type: 'POST',
@@ -359,14 +357,12 @@
         dataType: 'json',
         success: function(res) {
           if (test) {
-              alert('Versions found: \n' + res.version.join(', '));
+            alert(
+                'New versions: \n' + res.found_versions.join(', ') + '\n' +
+                'All versions: \n' + res.versions.join(', ') + '\n' +
+                'Latest version: ' + res.latest_version
+            );
           } else {
-            if (res.version) {
-              output = res.version;
-            } else {
-              output = res.error;
-            }
-            $('#version_info').html("Latest versions: " + output);
             window.location.reload(false);
           }
           $(btn).show(); $(btn + "-spinner").hide();
@@ -375,7 +371,7 @@
           $(btn).show(); $(btn + "-spinner").hide();
           alert(
               'Unable to retrieve the latest version from upstream!\n'
-              + 'ERROR: ' + res.responseJSON.error );
+              + 'ERROR: ' + res.responseJSON );
         }
     });
   };

--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -76,6 +76,14 @@
             </tr>
             {%- endif -%}
           </table>
+          <button type="submit" class="btn btn-success btn-sm pull-right"
+                  id="testcheck" tabindex=12>
+              <span class="glyphicon glyphicon-refresh"></span>
+              Test check
+          </button>
+          <img src="{{url_for('anitya_ui.static', filename='img/spinner.gif')}}"
+               id="testcheck-spinner" class="pull-right"
+               style="display: none; padding-top: 12px; padding-right: 25px;"/>
         </span>
       </div>
     </div>
@@ -315,6 +323,57 @@
       });
   }
 
+  function checkrelease(){
+    var btn = '#checknow';
+    $(btn).hide(); $(btn + "-spinner").show();
+    var _name = $('#name').val();
+    var _homepage = $('#homepage').val();
+    var _backend = $('#backend').val();
+    var _version_scheme = $('#version_scheme').val();
+    var _version_pattern = $('#version_pattern').val();
+    var _version_url = $('#version_url').val();
+    var _version_prefix = $('#version_prefix').val();
+    var _pre_release_filter = $('#pre_release_filter').val();
+    var _regex = $('#regex').val();
+    var _releases_only = $('#releases_only').is(':checked');
+    var _insecure = $('#insecure').is(':checked');
+    var _url = "{{ url_for('apiv2.versions')}}";
+    data = {
+        name: _name,
+        homepage: _homepage,
+        backend: _backend,
+        version_scheme: _version_scheme,
+        version_pattern: _version_pattern,
+        version_url: _version_url,
+        version_prefix: _version_prefix,
+        pre_release_filter: _pre_release_filter,
+        regex: _regex,
+        releases_only: _releases_only,
+        insecure: _insecure,
+        dry_run: true,
+    };
+    $.ajax({
+        url: _url ,
+        type: 'POST',
+        data: data,
+        dataType: 'json',
+        success: function(res) {
+          alert(
+              'New versions: \n' + res.found_versions.join(', ') + '\n' +
+              'All versions: \n' + res.versions.join(', ') + '\n' +
+              'Latest version: ' + res.latest_version
+          );
+          $(btn).show(); $(btn + "-spinner").hide();
+        },
+        error: function(res) {
+          $(btn).show(); $(btn + "-spinner").hide();
+          alert(
+              'Unable to retrieve the latest version from upstream!\n'
+              + 'ERROR: ' + res.responseJSON );
+        }
+    });
+  };
+
   $(document).ready(function() {
     $('#info_field').hide();
     show_hide();
@@ -376,5 +435,10 @@
     });
   });
   {% endif %}
+
+  $('#testcheck').click(function(){
+      checkrelease();
+      return false;
+  });
 </script>
 {% endblock %}

--- a/files/anitya.toml.sample
+++ b/files/anitya.toml.sample
@@ -60,6 +60,9 @@ default_regex = """\
 
 # Github access token
 # This is used by GitHub API for github backend
+# Permission needed by Anitya:
+# * repo:status
+# * public_repo
 github_access_token = "foobar"
 
 # Check service configuration

--- a/news/491.api
+++ b/news/491.api
@@ -1,0 +1,1 @@
+Add versions resource to API v2

--- a/news/491.feature
+++ b/news/491.feature
@@ -1,0 +1,1 @@
+Add preview mode


### PR DESCRIPTION
This adds API v2 versions target with GET and POST methods.
* GET method allows user to get versions that are currently available on the project.
* POST allows user to apply temporary changes and run a check for new
  versions above the project.

Add "Test check" button to add/edit project page to allow users to test
changes before submitting.

Update `check_project_release`, `create_project` and `edit_project` methods to allow dry_run.

Closes #491

Signed-off-by: Michal Konečný <mkonecny@redhat.com>