### PR TITLE
Add stable_versions field to APIv1 and APIv2

### DIFF
--- a/anitya/api_v2.py
+++ b/anitya/api_v2.py
@@ -331,6 +331,15 @@ class ProjectsResource(Resource):
                             "2.9",
                             "2.8",
                             "2.7"
+                        ],
+                        "stable_versions": [
+                            "2.12",
+                            "2.11",
+                            "2.10",
+                            "2.9.1",
+                            "2.9",
+                            "2.8",
+                            "2.7"
                         ]
                     }
                 ],
@@ -419,7 +428,8 @@ class ProjectsResource(Resource):
                 "updated_on": 1490543790.0,
                 "version": null,
                 "version_url": null,
-                "versions": []
+                "versions": [],
+                "stable_versions": []
             }
 
         :query string access_token: Your API access token.
@@ -545,6 +555,15 @@ class VersionsResource(Resource):
                     "2.9",
                     "2.8",
                     "2.7"
+                ],
+                "stable_versions": [
+                    "2.12",
+                    "2.11",
+                    "2.10",
+                    "2.9.1",
+                    "2.9",
+                    "2.8",
+                    "2.7"
                 ]
             }
 
@@ -566,6 +585,7 @@ class VersionsResource(Resource):
         response = {
             "latest_version": project.latest_version,
             "versions": project.versions,
+            "stable_versions": [v.version for v in project.stable_versions],
         }
         return response
 
@@ -608,6 +628,10 @@ class VersionsResource(Resource):
                 "found_versions": [],
                 "latest_version": "0.0.2",
                 "versions": [
+                    "0.0.2",
+                    "0.0.1"
+                ],
+                "stable_versions": [
                     "0.0.2",
                     "0.0.1"
                 ]
@@ -870,5 +894,6 @@ class VersionsResource(Resource):
                 "latest_version": project.latest_version,
                 "found_versions": versions,
                 "versions": project.versions,
+                "stable_versions": [v.version for v in project.stable_versions],
             }
             return response

--- a/anitya/db/models.py
+++ b/anitya/db/models.py
@@ -464,6 +464,7 @@ class Project(Base):
             version_url=self.version_url,
             version=self.latest_version,
             versions=self.versions,
+            stable_versions=[v.version for v in self.stable_versions],
             created_on=time.mktime(self.created_on.timetuple())
             if self.created_on
             else None,

--- a/anitya/tests/db/test_meta.py
+++ b/anitya/tests/db/test_meta.py
@@ -129,6 +129,7 @@ class BaseQueryPaginateTests(DatabaseTestCase):
                     "version": None,
                     "version_url": None,
                     "versions": [],
+                    "stable_versions": [],
                 }
             ],
         }

--- a/anitya/tests/test_flask_api.py
+++ b/anitya/tests/test_flask_api.py
@@ -104,6 +104,7 @@ class AnityaWebAPItests(DatabaseTestCase):
                     "version": None,
                     "version_url": "https://www.geany.org/Download/Releases",
                     "versions": [],
+                    "stable_versions": [],
                 },
                 {
                     "id": 3,
@@ -115,6 +116,7 @@ class AnityaWebAPItests(DatabaseTestCase):
                     "version": None,
                     "version_url": None,
                     "versions": [],
+                    "stable_versions": [],
                 },
                 {
                     "id": 2,
@@ -126,6 +128,7 @@ class AnityaWebAPItests(DatabaseTestCase):
                     "version": None,
                     "version_url": "https://subsurface-divelog.org/downloads/",
                     "versions": [],
+                    "stable_versions": [],
                 },
             ],
             "total": 3,
@@ -153,6 +156,7 @@ class AnityaWebAPItests(DatabaseTestCase):
                     "version": None,
                     "version_url": "https://www.geany.org/Download/Releases",
                     "versions": [],
+                    "stable_versions": [],
                 }
             ],
             "total": 1,
@@ -180,6 +184,7 @@ class AnityaWebAPItests(DatabaseTestCase):
                     "version": None,
                     "version_url": "https://www.geany.org/Download/Releases",
                     "versions": [],
+                    "stable_versions": [],
                 }
             ],
             "total": 1,
@@ -354,6 +359,7 @@ class AnityaWebAPItests(DatabaseTestCase):
             "version": None,
             "version_url": "https://www.geany.org/Download/Releases",
             "versions": [],
+            "stable_versions": [],
             "packages": [{"distro": "Fedora", "package_name": "geany"}],
         }
 
@@ -402,6 +408,7 @@ class AnityaWebAPItests(DatabaseTestCase):
             "version": None,
             "version_url": "https://www.geany.org/Download/Releases",
             "versions": [],
+            "stable_versions": [],
             "packages": [{"distro": "Fedora", "package_name": "geany"}],
         }
 
@@ -449,6 +456,7 @@ class AnityaWebAPItests(DatabaseTestCase):
             "version": None,
             "version_url": None,
             "versions": [],
+            "stable_versions": [],
             "packages": [],
         }
 

--- a/anitya/tests/test_flask_api_v2.py
+++ b/anitya/tests/test_flask_api_v2.py
@@ -694,6 +694,7 @@ class ProjectsResourceGetTests(DatabaseTestCase):
                     "version": None,
                     "version_url": None,
                     "versions": [],
+                    "stable_versions": [],
                     "ecosystem": "https://fedorahosted.org/r2spec/",
                 },
                 {
@@ -705,6 +706,7 @@ class ProjectsResourceGetTests(DatabaseTestCase):
                     "version": None,
                     "version_url": "https://www.geany.org/Download/Releases",
                     "versions": [],
+                    "stable_versions": [],
                     "ecosystem": "https://www.geany.org/",
                 },
                 {
@@ -716,6 +718,7 @@ class ProjectsResourceGetTests(DatabaseTestCase):
                     "version": None,
                     "version_url": "https://subsurface-divelog.org/downloads/",
                     "versions": [],
+                    "stable_versions": [],
                     "ecosystem": "https://subsurface-divelog.org/",
                 },
             ],
@@ -765,6 +768,7 @@ class ProjectsResourceGetTests(DatabaseTestCase):
                     "version": None,
                     "version_url": None,
                     "versions": [],
+                    "stable_versions": [],
                     "ecosystem": "http://www.zlib.net/",
                 },
                 {
@@ -776,6 +780,7 @@ class ProjectsResourceGetTests(DatabaseTestCase):
                     "version": None,
                     "version_url": None,
                     "versions": [],
+                    "stable_versions": [],
                     "ecosystem": "https://hackage.haskell.org/package/zlib",
                 },
             ],
@@ -811,6 +816,7 @@ class ProjectsResourceGetTests(DatabaseTestCase):
                     "version": None,
                     "version_url": "https://subsurface-divelog.org/downloads/",
                     "versions": [],
+                    "stable_versions": [],
                     "ecosystem": "https://subsurface-divelog.org/",
                 }
             ],
@@ -844,6 +850,7 @@ class ProjectsResourceGetTests(DatabaseTestCase):
                     "version": None,
                     "version_url": "https://subsurface-divelog.org/downloads/",
                     "versions": [],
+                    "stable_versions": [],
                     "ecosystem": "https://subsurface-divelog.org/",
                 }
             ],
@@ -877,6 +884,7 @@ class ProjectsResourceGetTests(DatabaseTestCase):
                     "version": None,
                     "version_url": "https://subsurface-divelog.org/downloads/",
                     "versions": [],
+                    "stable_versions": [],
                     "ecosystem": "https://subsurface-divelog.org/",
                 }
             ],
@@ -919,6 +927,7 @@ class ProjectsResourceGetTests(DatabaseTestCase):
                     "version": None,
                     "version_url": None,
                     "versions": [],
+                    "stable_versions": [],
                     "ecosystem": "https://fedorahosted.org/r2spec/",
                 }
             ],
@@ -961,6 +970,7 @@ class ProjectsResourceGetTests(DatabaseTestCase):
                     "version": None,
                     "version_url": "https://www.geany.org/Download/Releases",
                     "versions": [],
+                    "stable_versions": [],
                     "ecosystem": "https://www.geany.org/",
                 }
             ],
@@ -1245,7 +1255,9 @@ class VersionsResourceGetTests(DatabaseTestCase):
         self.assertEqual(output.status_code, 200)
         data = _read_json(output)
 
-        self.assertEqual(data, {"latest_version": None, "versions": []})
+        self.assertEqual(
+            data, {"latest_version": None, "versions": [], "stable_versions": []}
+        )
 
     def test_list_versions(self):
         """Assert versions are returned when they exist."""
@@ -1269,7 +1281,11 @@ class VersionsResourceGetTests(DatabaseTestCase):
         self.assertEqual(output.status_code, 200)
         data = _read_json(output)
 
-        exp = {"latest_version": "1.0.0", "versions": ["1.0.0", "0.9.9"]}
+        exp = {
+            "latest_version": "1.0.0",
+            "versions": ["1.0.0", "0.9.9"],
+            "stable_versions": ["1.0.0", "0.9.9"],
+        }
 
         self.assertEqual(data, exp)
 
@@ -1416,6 +1432,7 @@ class VersionsResourcePostTests(DatabaseTestCase):
             "latest_version": None,
             "found_versions": ["1.0.0", "0.9.9"],
             "versions": [],
+            "stable_versions": [],
         }
         self.assertEqual(data, exp)
 
@@ -1445,6 +1462,7 @@ class VersionsResourcePostTests(DatabaseTestCase):
             "latest_version": None,
             "found_versions": ["1.0.0", "0.9.9"],
             "versions": [],
+            "stable_versions": [],
         }
         self.assertEqual(data, exp)
 
@@ -1505,6 +1523,7 @@ class VersionsResourcePostTests(DatabaseTestCase):
             "latest_version": None,
             "found_versions": ["1.0.0", "0.9.9"],
             "versions": [],
+            "stable_versions": [],
         }
         self.assertEqual(data, exp)
 
@@ -1549,6 +1568,7 @@ class VersionsResourcePostTests(DatabaseTestCase):
             "latest_version": None,
             "found_versions": ["1.0.0", "0.9.9"],
             "versions": [],
+            "stable_versions": [],
         }
         self.assertEqual(data, exp)
 

--- a/news/1014.api
+++ b/news/1014.api
@@ -1,0 +1,1 @@
+Add stable_versions field to APIv1 and APIv2


### PR DESCRIPTION
This commit introduces stable_versions to both API provided by Anitya.
Till now the stable versions were only sent in Fedora messaging message,
but missing in API.

Closes #1014 

Signed-off-by: Michal Konečný <mkonecny@redhat.com>