### PR TITLE
Don't add projects with blacklisted backend to check queue

### DIFF
--- a/anitya/check_service.py
+++ b/anitya/check_service.py
@@ -300,7 +300,15 @@ class Checker:
             .all()
         )
 
-        queue += [project.id for project in projects]
+        # Create list of projects that should be checked but belong to blacklisted backend
+        blacklisted_projects = []
+        for project in projects:
+            if project.backend in self.blacklist_dict.keys():
+                blacklisted_projects.append(project)
+
+        queue += [
+            project.id for project in projects if project not in blacklisted_projects
+        ]
 
         # Use ordered set to have the order of the elements, but still have uniqueness
         ord_set = OrderedSet(queue)

--- a/news/888.feature
+++ b/news/888.feature
@@ -1,0 +1,1 @@
+Don't add project to check queue if they belong to blacklisted backend


### PR DESCRIPTION
It doesn't make much sense to add projects from blacklisted backend to
check queue when they will be skipped anyway.

This will make run statistics make clearer and will add the projects that
were in the run when the backend was blacklisted to be checked first.

Closes #888

Signed-off-by: Michal Konečný <mkonecny@redhat.com>