### PR TITLE
Remove prefix from stable_versions field in APIs

### DIFF
--- a/anitya/api_v2.py
+++ b/anitya/api_v2.py
@@ -585,7 +585,7 @@ class VersionsResource(Resource):
         response = {
             "latest_version": project.latest_version,
             "versions": project.versions,
-            "stable_versions": [v.version for v in project.stable_versions],
+            "stable_versions": [str(v) for v in project.stable_versions],
         }
         return response
 
@@ -894,6 +894,6 @@ class VersionsResource(Resource):
                 "latest_version": project.latest_version,
                 "found_versions": versions,
                 "versions": project.versions,
-                "stable_versions": [v.version for v in project.stable_versions],
+                "stable_versions": [str(v) for v in project.stable_versions],
             }
             return response

--- a/anitya/db/models.py
+++ b/anitya/db/models.py
@@ -464,7 +464,7 @@ class Project(Base):
             version_url=self.version_url,
             version=self.latest_version,
             versions=self.versions,
-            stable_versions=[v.version for v in self.stable_versions],
+            stable_versions=[str(v) for v in self.stable_versions],
             created_on=time.mktime(self.created_on.timetuple())
             if self.created_on
             else None,

--- a/news/1026.bug
+++ b/news/1026.bug
@@ -1,0 +1,1 @@
+Stable versions in the APIs are sent with prefix


### PR DESCRIPTION
In release 1.1.0 we added stable_versions to APIs, this commit will sent
it correctly without prefix.

Fixes #1026

Signed-off-by: Michal Konecny <michal.konecny@packetseekers.eu>