### PR TITLE
Fix crash when tag is missing

### DIFF
--- a/anitya/lib/backends/github.py
+++ b/anitya/lib/backends/github.py
@@ -247,9 +247,15 @@ def parse_json(json, project):
         else:
             hook = edge["node"]
 
-        version["version"] = hook["name"]
-        version["commit_url"] = hook["target"]["commitUrl"]
-        versions.append(version)
+        if hook:
+            version["version"] = hook["name"]
+            version["commit_url"] = hook["target"]["commitUrl"]
+            versions.append(version)
+        else:
+            _log.info(
+                "Skipping release %s on %s, because it doesn't have associated tag"
+                % (edge["node"]["name"], project.name)
+            )
 
     return versions
 

--- a/anitya/tests/lib/backends/test_github.py
+++ b/anitya/tests/lib/backends/test_github.py
@@ -577,6 +577,33 @@ class JsonTests(unittest.TestCase):
             backend.parse_json(json, project)
         self.assertEqual(backend.reset_time, "2008-09-03T20:56:35.450686")
 
+    def test_parse_json_tag_missing(self):
+        """Test parsing a JSON skips releases where tag is missing."""
+        project = models.Project(
+            name="foobar",
+            homepage="https://foobar.com",
+            version_url="foo/bar",
+            backend=BACKEND,
+            releases_only=True,
+        )
+        json = {
+            "data": {
+                "repository": {
+                    "releases": {
+                        "totalCount": 1,
+                        "edges": [
+                            {
+                                "node": {"name": "This is a release", "tag": None},
+                            },
+                        ],
+                    },
+                },
+                "rateLimit": {"limit": 5000, "remaining": 5000, "resetAt": "dummy"},
+            }
+        }
+        obs = backend.parse_json(json, project)
+        self.assertEqual([], obs)
+
 
 if __name__ == "__main__":
     SUITE = unittest.TestLoader().loadTestsFromTestCase(GithubBackendtests)

--- a/news/1029.bug
+++ b/news/1029.bug
@@ -1,0 +1,1 @@
+Crash when release doesn't have tag associated in GitHub backend


### PR DESCRIPTION
When GitHub backend encountered a release which was missing a tag
associated with it, it crashed the whole Anitya. This commit is fixing
this bug by skipping releases without associated tag.

Fixes #1029

Signed-off-by: Michal Konečný <mkonecny@redhat.com>