### PR TITLE
 Link Fedora packages to their source (#557)

### DIFF
--- a/anitya/templates/project.html
+++ b/anitya/templates/project.html
@@ -186,7 +186,15 @@
                 {% for package in project.packages %}
                 <tr>
                   <td>{{ package.distro_name }}</td>
-                  <td>{{ package.package_name }}</td>
+                  <td>
+                    {% if package.distro_name == 'Fedora' %}
+                      <a href="https://src.fedoraproject.org/rpms/{{ package.package_name }}">
+                        {{ package.package_name }}
+                      </a>
+                    {% else %}
+                      {{ package.package_name }}
+                    {% endif %}
+                  </td>
                   <td>
                     <a href="{{
                       url_for('anitya_ui.edit_project_mapping',

--- a/news/557.feature
+++ b/news/557.feature
@@ -1,0 +1,1 @@
+Link Fedora packages to their source


### PR DESCRIPTION
Because there are no package pages yet,
and because it is easier to track when the
package version will appear there.

Closes #557.