### PR TITLE
Added mypy POC and attempted to fix issues 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ docs/docblocks/
 *egg-info/
 *eggs/
 *.cfg
+!mypy.cfg
 *.sqlite
 *~
 *.swp

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,4 +1,20 @@
 - job:
+    name: tox-mypy
+    description: |
+      Run static-linker tests with mypy.
+
+      Uses tox with ``mypy`` environment.
+
+    parent: tox
+    run: ci/test-tox.yaml
+    vars:
+      tox_env: mypy
+    nodeset:
+      nodes:
+        name: test-node
+        label: pod-python-f33
+
+- job:
     name: tox-lint
     description: |
       Run lint tests using tox.
@@ -13,7 +29,6 @@
       nodes:
         name: test-node
         label: pod-python-f33
-
 - job:
     name: tox-format
     description: |
@@ -25,21 +40,6 @@
     run: ci/test-tox.yaml
     vars:
       tox_env: format
-    nodeset:
-      nodes:
-        name: test-node
-        label: pod-python-f33
-- job:
-    name: tox-mypy
-    description: |
-      Run static lint tests using tox.
-
-      Uses tox with ``mypy`` environment.
-
-    parent: tox
-    run: ci/test-tox.yaml
-    vars:
-      tox_env: mypy 
     nodeset:
       nodes:
         name: test-node
@@ -143,9 +143,9 @@
 - project:
     check:
       jobs:
+        - tox-mypy
         - tox-lint
         - tox-format
-        - tox-mypy
         - tox-python38
         - tox-python39
         - anitya-tox-docs

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -29,22 +29,17 @@
       nodes:
         name: test-node
         label: pod-python-f33
-
 - job:
-    name: tox-python37
+    name: tox-mypy
     description: |
-      Run unit tests for a Python project under cPython version 3.7.
+      Run static lint tests using tox.
 
-      Uses tox with the ``py37`` environment.
-
-      Ensures that the python37 interpreter is installed.
+      Uses tox with ``mypy`` environment.
 
     parent: tox
     run: ci/test-tox.yaml
     vars:
-      tox_env: py37
-      dependencies:
-        - python37
+      tox_env: mypy 
     nodeset:
       nodes:
         name: test-node
@@ -150,7 +145,7 @@
       jobs:
         - tox-lint
         - tox-format
-        - tox-python37
+        - tox-mypy
         - tox-python38
         - tox-python39
         - anitya-tox-docs

--- a/anitya/config.py
+++ b/anitya/config.py
@@ -96,7 +96,7 @@ DEFAULTS = dict(
 
 # Start with a basic logging configuration, which will be replaced by any user-
 # specified logging configuration when the configuration is loaded.
-logging.config.dictConfig(DEFAULTS["ANITYA_LOG_CONFIG"])
+logging.config.dictConfig(DEFAULTS["ANITYA_LOG_CONFIG"])  # type: ignore
 
 
 def load():

--- a/anitya/db/models.py
+++ b/anitya/db/models.py
@@ -19,15 +19,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """SQLAlchemy database models."""
 
-try:
-    # The Python 3.6+ API
-    from secrets import choice as random_choice
-except ImportError:  # pragma: no cover
-    # Fall back to random with os.urandom
-    import random
-
-    random = random.SystemRandom()
-    random_choice = random.choice
+from secrets import choice as random_choice
 import datetime
 import arrow
 import logging

--- a/anitya/forms.py
+++ b/anitya/forms.py
@@ -23,16 +23,12 @@ class TokenForm(FlaskForm):
 class ProjectForm(FlaskForm):
     name = StringField("Project name", [validators.DataRequired()])
     homepage = StringField("Homepage", [validators.DataRequired(), validators.URL()])
-    backend = SelectField(
-        "Backend", [validators.DataRequired()], choices=[(item, item) for item in []]
-    )
+    backend = SelectField("Backend", [validators.DataRequired()], choices=[])
     version_url = StringField("Version URL", [validators.optional()])
     version_prefix = StringField("Version prefix", [validators.optional()])
     pre_release_filter = StringField("Pre-release filter", [validators.optional()])
     version_filter = StringField("Version filter", [validators.optional()])
-    version_scheme = SelectField(
-        "Version scheme", [validators.Required()], choices=[(item, item) for item in []]
-    )
+    version_scheme = SelectField("Version scheme", [validators.Required()], choices=[])
     version_pattern = StringField("Version pattern", [validators.optional()])
     regex = StringField("Regex", [validators.optional()])
     insecure = BooleanField("Use insecure connection", [validators.optional()])

--- a/anitya/lib/backends/__init__.py
+++ b/anitya/lib/backends/__init__.py
@@ -26,6 +26,7 @@ from datetime import timedelta
 
 # sre_constants contains re exceptions
 import sre_constants
+from typing import List
 import urllib.request as urllib
 from urllib.error import URLError
 
@@ -35,7 +36,8 @@ import arrow
 
 from anitya.config import config as anitya_config
 from anitya.lib.exceptions import AnityaPluginException
-from anitya.lib.versions import RpmVersion
+from anitya.lib.versions import GLOBAL_DEFAULT, RpmVersion
+
 import six
 
 REGEX = anitya_config["DEFAULT_REGEX"]
@@ -79,11 +81,11 @@ class BaseBackend(object):
             checking for new versions. This could be overriden by backend plugin.
     """
 
-    name = None
-    examples = None
-    default_regex = None
-    more_info = None
-    default_version_scheme = None
+    name: str
+    examples: List[str]
+    default_regex: str
+    more_info: str
+    default_version_scheme = GLOBAL_DEFAULT
     check_interval = timedelta(hours=1)
 
     @classmethod

--- a/anitya/lib/ecosystems/__init__.py
+++ b/anitya/lib/ecosystems/__init__.py
@@ -12,6 +12,10 @@
 """
 
 
+from typing import List
+from anitya.lib.versions import GLOBAL_DEFAULT as DEFAULT_VERSION_SCHEME
+
+
 class BaseEcosystem(object):
     """
     The base class that all the different ecosystems should extend.
@@ -28,7 +32,7 @@ class BaseEcosystem(object):
             should be lowercase.
     """
 
-    name = None
-    default_backend = None
-    default_version_scheme = None
-    aliases = []
+    name: str
+    default_backend: str
+    default_version_scheme: str = DEFAULT_VERSION_SCHEME
+    aliases: List[str] = []

--- a/anitya/lib/versions/base.py
+++ b/anitya/lib/versions/base.py
@@ -75,10 +75,9 @@ class Version(object):
         else:
             self.prefixes = []
         self.created_on = created_on
+        self.pattern = None
         if pattern:
             self.pattern = pattern.upper()
-        else:
-            self.pattern = None
         self.cursor = cursor
         self.commit_url = commit_url
         if pre_release_filter:

--- a/anitya/lib/versions/rpm.py
+++ b/anitya/lib/versions/rpm.py
@@ -48,10 +48,7 @@ except ImportError:
 
     warnings.warn("Failed to import 'rpm', emulating RPM label comparisons")
 
-    try:
-        from itertools import zip_longest
-    except ImportError:
-        from itertools import izip_longest as zip_longest
+    from itertools import zip_longest
 
     _subfield_pattern = re.compile(
         r"(?P<junk>[^a-zA-Z0-9]*)((?P<text>[a-zA-Z]+)|(?P<num>[0-9]+))"

--- a/anitya/mail_logging.py
+++ b/anitya/mail_logging.py
@@ -34,7 +34,9 @@ import flask
 
 psutil = None
 try:
-    import psutil
+    import psutil as _psutil
+
+    psutil = _psutil
 except (OSError, ImportError):  # pragma: no cover
     # We run into issues when trying to import psutil from inside mod_wsgi on
     # rhel7.  If we hit that here, then just fail quietly.

--- a/anitya/mail_logging.py
+++ b/anitya/mail_logging.py
@@ -36,7 +36,7 @@ psutil = None
 try:
     import psutil as _psutil
 
-    psutil = _psutil
+    psutil = _psutil  # pragma: no cover
 except (OSError, ImportError):  # pragma: no cover
     # We run into issues when trying to import psutil from inside mod_wsgi on
     # rhel7.  If we hit that here, then just fail quietly.

--- a/anitya/tests/lib/versions/test_calver.py
+++ b/anitya/tests/lib/versions/test_calver.py
@@ -488,6 +488,7 @@ class CalendarVersionTests(unittest.TestCase):
 
     def test_lt_nonsense(self):
         """Assert CalendarVersion supports < comparison."""
+        # unclear if it should really be valid -junk modifier?
         old_version = calver.CalendarVersion(
             version="2019.04.23junk", pattern="YYYY.0M.DD-MODIFIER"
         )

--- a/anitya/tests/lib/versions/test_calver.py
+++ b/anitya/tests/lib/versions/test_calver.py
@@ -550,6 +550,13 @@ class CalendarVersionTests(unittest.TestCase):
         self.assertTrue(new_version >= equally_new_version)
         self.assertTrue(new_version >= old_version)
 
+    def test_eq_wrong_type(self):
+        """Assert CalendarVersion returns not implemented if other is not Version object."""
+        new_version = calver.CalendarVersion(
+            version="2019.04.23", pattern="YYYY.0M.DD-MODIFIER"
+        )
+        self.assertEqual(new_version.__eq__("2019.04.23"), NotImplemented)
+
     def test_eq(self):
         """Assert CalendarVersion supports == comparison."""
         old_version = calver.CalendarVersion(

--- a/anitya_schema/setup.py
+++ b/anitya_schema/setup.py
@@ -35,9 +35,6 @@ setup(
     classifiers=[
         "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
         "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
     license="GPLv2+",

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -15,7 +15,7 @@ will review your code. Please make sure you follow the guidelines below:
 Python Support
 --------------
 
-Anitya supports Python 3.6 or greater so please ensure the code
+Anitya supports Python 3.8 or greater so please ensure the code
 you submit works with these versions. The test suite will run against all supported
 Python versions to make this easier.
 

--- a/mypy.cfg
+++ b/mypy.cfg
@@ -1,0 +1,8 @@
+# Global options:
+
+[mypy]
+python_version = 3.8
+warn_return_any = True
+warn_unused_configs = True
+ignore_missing_imports = True
+strict_optional = True

--- a/news/PR1114.dev
+++ b/news/PR1114.dev
@@ -1,0 +1,2 @@
+Introduced static-type checking through inclusion of mypy in tox.
+Removed 3.6 and 3.7 from the list of supported python versions.

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     packages=find_packages(exclude=["anitya.tests", "anitya.tests.*"]),
     include_package_data=True,
     scripts=[

--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,6 @@ setup(
     download_url="https://fedorahosted.org/releases/a/n/anitya/",
     url="https://fedorahosted.org/anitya/",
     classifiers=[
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
     ],

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -18,3 +18,12 @@ requests-oauthlib==1.3.0
 sphinx==4.0.3
 sphinxcontrib-httpdomain==1.7.0
 sqlalchemy_schemadisplay==1.3
+
+# Mypy test requirements
+mypy==0.910
+types-mock==0.1.3
+types-python-dateutil==0.1.4
+types-requests==2.25.1
+types-setuptools==57.0.0
+types-six==0.1.7
+types-toml==0.1.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,diff-cover,lint,format,bandit,docs
+envlist = mypy,py38,diff-cover,lint,format,bandit,docs
 
 [testenv]
 passenv = TRAVIS TRAVIS_*
@@ -53,6 +53,16 @@ deps =
     -rtest_requirements.txt
 commands =
     bandit -r anitya/ anitya_schema/anitya_schema/ -x anitya/db/migrations/* -ll
+
+[testenv:mypy]
+basepython = python3.9
+deps =h
+    -rrequirements.txt
+    -rtest_requirements.txt
+    mypy
+setenv =
+    MYPYPATH={toxinidir}
+commands = mypy --config-file {toxinidir}/mypy.cfg anitya anitya_schema
 
 [flake8]
 show-source = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = mypy,py38,diff-cover,lint,format,bandit,docs
+envlist = mypy,py38,py39,diff-cover,lint,format,bandit,docs
 
 [testenv]
 passenv = TRAVIS TRAVIS_*

--- a/tox.ini
+++ b/tox.ini
@@ -56,10 +56,9 @@ commands =
 
 [testenv:mypy]
 basepython = python3.9
-deps =h
+deps =
     -rrequirements.txt
     -rtest_requirements.txt
-    mypy
 setenv =
     MYPYPATH={toxinidir}
 commands = mypy --config-file {toxinidir}/mypy.cfg anitya anitya_schema


### PR DESCRIPTION
Added mypy and attempted to fix issues  resulting from additional type-annotations. Removed py36.

Things I am not sure about:

**The calendar comparisons:** https://github.com/fedora-infra/anitya/compare/master...AdamSaleh:anitya_mypy_poc?expand=1#diff-6d66ea3411d110aa6961c53b9437d5adcecd56119de31c6a7530df1aa15314c3R491

I might go over-board with the isInstance checks, so some things are not comparable that were before. Or I have uncovered bug in the implementation? :-) If it's the former, I would like to figure out a way how to do this with mypy.

**The defaults (that are not None):** https://github.com/fedora-infra/anitya/compare/master...AdamSaleh:anitya_mypy_poc?expand=1#diff-7c42726a003d98fb9eab5f791a56c51d0422dde1d49020ec105961e0eadbdea3R86

Some should be easy, i.e. empty-list can be used in most places instead of None, because it already is False-y.
Some I am not sure about, like default REGEX, e.t.c.

**Typed dictionary**: it is really cool for mypy to shout at you when you have typo in your dictionary keys. But there already is support for dictionaries that don't contain all of the keys, and we might want to use that instead of lots of {key : None} initialization
