### PR TITLE
Small fixes in dependencies

### DIFF
--- a/ansible/roles/anitya-dev/tasks/main.yml
+++ b/ansible/roles/anitya-dev/tasks/main.yml
@@ -42,6 +42,7 @@
            fedora-messaging,
            python3-alembic,
            python3-arrow,
+           python3-beautifulsoup4,
            python3-dateutil,
            python3-defusedxml,
            python3-flask-login,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 alembic>=1.3.1, <2.0.0
 arrow>=0.14.6, <2.0.0
-bs4>=0.0.1, <1.0.0
+beautifulsoup4>=4.9.3, <5.0.0
 defusedxml>=0.6.0, <1.0.0
 fedora_messaging>=2.0.1, <3.0.0
 flask>=1.1.4, <3.0.0


### PR DESCRIPTION
* Use beatifulsoup4 fedora package in vagrant
* Use beatifulsoup4 dependency instead of bs4 dummy package

Signed-off-by: Michal Konečný <mkonecny@redhat.com>