### PR TITLE
Fix multiple small (but sometimes serious) issues

### DIFF
--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -263,7 +263,7 @@
         "'https://packagist.org/packages/phpunit/php-code-coverage' " +
         "this field should contain 'phpunit/php-code-coverage'.");
     };
-    if (str == 'Sourceforge') || (str == 'Sourceforge (git)){
+    if ((str == 'Sourceforge') || (str == 'Sourceforge (git)')){
       $("label[for='version_url']").text('Sourceforge name');
       $('#version_url').prop('title', "Use this field if the name used " +
         "on the rss page of the project differs from the name of the project." );

--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -379,7 +379,7 @@
           $(btn).show(); $(btn + "-spinner").hide();
           alert(
               'Unable to retrieve the latest version from upstream!\n'
-              + 'ERROR: ' + res.responseJSON );
+              + 'ERROR: ' + JSON.stringify(res.responseJSON) );
         }
     });
   };

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -207,8 +207,8 @@ The backends available are:
   You need to provide **Sourceforge name** if the name on RSS feed is different then the
   project name on Sourceforge.
 
-* **Sourceforge (git) for projects hosted on
-  `sourceforge.net <https://sourceforge.net>`_
+* **Sourceforge (git)** for projects hosted on
+  `sourceforge.net <https://sourceforge.net>`__
 
   Sourceforge (git) retrieves the git tags in case a project hosted on sourceforge has them.
   When a url to get the tags from is not provided, the sourceforge homepage of a project

--- a/news/PR1144.bug
+++ b/news/PR1144.bug
@@ -1,0 +1,1 @@
+Fix documentation and javascript issues


### PR DESCRIPTION
Master branch has multiple issues small (but sometimes very serious).

## Vagrant development environment setup failed during 'vagrant up'
Errors during from task _Build the Anitya documentation_:

> user-guide.rst:210:Inline strong start-string without end-string.
> user-guide.rst:3:Duplicate explicit target name: \"sourceforge.net\"

Like the errors say, the entry about _Sourceforge (git)_ was corrupted
in two different ways:
1. Strong string was started with `**`, but never terminated.
   The fix is obvious.
2. The same document had two links using format '\`text <url>\`_',
   which is not allowed in reStructured Text.
   Fixed by using '__' in the second link, making it "anonymous".

## Fix corrupted javascript
Caused the page it was on malfunction in serious ways.

##  Display error correctly when Test Check fails
When Test Check failed in the Edit Project page,
resulting error was displayed as '[Object object]'.
This was a result of concatenating an object to string.
Fixed by using JSON.stringify().