### PR TITLE
Use version filter during Edit Project Test Check

### DIFF
--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -342,6 +342,7 @@
     var _version_url = $('#version_url').val();
     var _version_prefix = $('#version_prefix').val();
     var _pre_release_filter = $('#pre_release_filter').val();
+    var _version_filter = $('#version_filter').val();
     var _regex = $('#regex').val();
     var _releases_only = $('#releases_only').is(':checked');
     var _insecure = $('#insecure').is(':checked');
@@ -355,6 +356,7 @@
         version_url: _version_url,
         version_prefix: _version_prefix,
         pre_release_filter: _pre_release_filter,
+        version_filter: _version_filter,
         regex: _regex,
         releases_only: _releases_only,
         insecure: _insecure,

--- a/news/1143.bug
+++ b/news/1143.bug
@@ -1,0 +1,1 @@
+Version Filter not applied on Test Check


### PR DESCRIPTION
The version filter input is on the page, api accepts it,
but it was not used.
Fixed by simply passing it in.
Now Test Check accurately shows the versions
resulting from  configuration on the page.

Fixes #1143

Signed-off-by: Otto Urpelainen <oturpe@iki.fi>