### PR TITLE
Downgrade Sphinx to compatible version 4.0.3

### DIFF
--- a/news/1148.bug
+++ b/news/1148.bug
@@ -1,0 +1,1 @@
+Downgrade Sphinx to compatible version 4.0.3

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -14,6 +14,7 @@ requests==2.26.0
 requests-oauthlib==1.3.0
 
 # Required to test building the docs
-sphinx==4.1.1
+# sphinxcontrib-httpdomain errors on Sphinx 4.1.x 
+sphinx==4.0.3
 sphinxcontrib-httpdomain==1.7.0
 sqlalchemy_schemadisplay==1.3


### PR DESCRIPTION
On Sphinx 4.1.1, Tox `docs` task fails due to following kind of error:
    
```
autoflask>:1:Problem in http domain: field is supposed to use role 'obj', but that role is not in the domain.
```
    
This does not happen on Sphinx 4.0.3, so downgrading to that.
    
Fixes #1148 

Also `.gitignore` improvement.