### PR TITLE
Better error message when GitHub token is missing

### DIFF
--- a/anitya/lib/backends/github.py
+++ b/anitya/lib/backends/github.py
@@ -99,8 +99,9 @@ class GithubBackend(BaseBackend):
         try:
             headers = REQUEST_HEADERS.copy()
             token = config["GITHUB_ACCESS_TOKEN"]
-            if token:
-                headers["Authorization"] = "bearer %s" % token
+            if not token:
+                raise AnityaPluginException("github_access_token not configured")
+            headers["Authorization"] = "bearer %s" % token
             resp = http_session.post(
                 API_URL,
                 json={"query": query},

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -152,6 +152,9 @@ to the Ansible provisioner inside your `Vagrantfile`::
 
     ansible.extra_vars = { import_production_database: false }
 
+The application's configuration file is ``/home/vagrant/anitya.toml``.
+You can also look at the `sample configuration <https://github.com/fedora-infra/anitya/blob/master/files/anitya.toml.sample>`_
+
 .. note::
    Please don't commit any local changes to Vagrantfile. We are managing it
    upstream.

--- a/news/PR1182.bug
+++ b/news/PR1182.bug
@@ -1,0 +1,1 @@
+Better error message when GitHub token is missing


### PR DESCRIPTION
In order to access GitHub during development,
GitHub access token needs to be manually set
in the configuration file.
This is unavoidable, since developer's own token is needed.
On the other hand,
the error message about missing token was not very clear
because it was just 401 Unauthenticated from GitHub.
A special error message for the case of unset token is added.
This tells developers clearly what is wrong in their setup
and is not worse than 401 in a production setup.