### PR TITLE
Fix mypy error

### DIFF
--- a/anitya/db/migrations/env.py
+++ b/anitya/db/migrations/env.py
@@ -18,7 +18,7 @@ config = context.config  # type: ignore
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-fileConfig(config.config_file_name)
+fileConfig(str(config.config_file_name))
 
 # add your model's MetaData object here
 # for 'autogenerate' support


### PR DESCRIPTION
`logging.config.fileConfig` doesn't allow `Optional[str]` anymore, so we
need to convert the value to str explicitly.

Fixes #1183

Signed-off-by: Michal Konečný <mkonecny@redhat.com>