### PR TITLE
Migrate social_auth to authlib

### DIFF
--- a/anitya/app.py
+++ b/anitya/app.py
@@ -16,17 +16,15 @@ import logging.handlers
 
 import flask
 from flask_login import LoginManager, current_user, user_logged_in
-from social_core.backends.utils import load_backends
-from social_core.exceptions import AuthException
-from social_flask.routes import social_auth
-from social_flask_sqlalchemy import models as social_models
+from flask import url_for, render_template
+from authlib.integrations.flask_client import OAuth
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
 from anitya.config import config as anitya_config
 from anitya.db import Session, initialize as initialize_db, models
 from anitya.lib import utilities
-from . import ui, admin, api, api_v2, authentication
+from . import ui, admin, api, api_v2, authentication, auth
 import anitya.lib
 import anitya.mail_logging
 from anitya import __version__
@@ -50,19 +48,6 @@ def create(config=None):
         config = anitya_config
     app.config.update(config)
     initialize_db(config)
-
-    app.register_blueprint(social_auth)
-    if len(social_models.UserSocialAuth.__table_args__) == 0:
-        # This is a bit of a hack - this initialization call sets up the SQLAlchemy
-        # models with our own models and multiple calls to this function will cause
-        # SQLAlchemy to fail with sqlalchemy.exc.InvalidRequestError. Only calling it
-        # when there are no table arguments should ensure we only call it one time.
-        #
-        # Be aware that altering the configuration values this function uses, namely
-        # the SOCIAL_AUTH_USER_MODEL, after the first time ``create`` has been called
-        # will *not* cause the new configuration to be used for subsequent calls to
-        # ``create``.
-        social_models.init_social(app, Session)
 
     login_manager = LoginManager()
     login_manager.user_loader(authentication.load_user_from_session)
@@ -88,10 +73,17 @@ def create(config=None):
     app.register_blueprint(ui.ui_blueprint)
     app.register_blueprint(api.api_blueprint)
 
+    oauth = OAuth(app)
+    for auth_backend in app.config.get("AUTHLIB_ENABLED_BACKENDS", []):
+        oauth.register(auth_backend.lower())
+
+    app.register_blueprint(auth.create_oauth_blueprint(oauth))
+
     app.before_request(global_user)
     app.teardown_request(shutdown_session)
     app.register_error_handler(IntegrityError, integrity_error_handler)
-    app.register_error_handler(AuthException, auth_error_handler)
+    # TODO: Need to change for authlib
+    #app.register_error_handler(AuthException, auth_error_handler)
 
     app.context_processor(inject_variable)
 
@@ -138,9 +130,7 @@ def inject_variable():
         justedit=justedit,
         cron_status=cron_status,
         user=current_user,
-        available_backends=load_backends(
-            anitya_config["SOCIAL_AUTH_AUTHENTICATION_BACKENDS"]
-        ),
+        available_backends=anitya_config["AUTHLIB_ENABLED_BACKENDS"],
     )
 
 
@@ -161,7 +151,7 @@ def integrity_error_handler(error):
         Session.rollback()
         other_user = models.User.query.filter_by(email=error.params["email"]).one()
         try:
-            social_auth_user = other_user.social_auth.filter_by(
+            social_auth_user = other_user.oauth.filter_by(
                 user_id=other_user.id
             ).one()
             msg = (
@@ -216,9 +206,10 @@ def when_user_log_in(sender, user):
         sqlalchemy.exc.IntegrityError: When user_social_auth table entry is
         missing.
     """
-    if user.social_auth.count() == 0:
-        raise IntegrityError(
-            "Missing social_auth table",
-            {"social_auth": None, "email": user.email},
-            None,
-        )
+    # TODO: new social table need to be added
+    #if user.oauth.count() == 0:
+    #    raise IntegrityError(
+    #        "Missing authlib table",
+    #        {"authlib": None, "email": user.email},
+    #        None,
+    #    )

--- a/anitya/auth.py
+++ b/anitya/auth.py
@@ -1,0 +1,59 @@
+import flask
+import flask_login
+
+from anitya.db import User, Session
+
+
+def create_oauth_blueprint(oauth):
+    oauth_blueprint = flask.Blueprint('oauth', __name__)
+
+    @oauth_blueprint.route("/oauthlogin/<name>")
+    def oauthlogin(name):
+        client = oauth.create_client(name)
+        if client is None:
+            flask.abort(400)
+        redirect_uri = flask.url_for('.auth', name=name, _external=True)
+        return client.authorize_redirect(redirect_uri)
+
+
+    @oauth_blueprint.route("/auth/<name>")
+    def auth(name):
+        client = oauth.create_client(name)
+        if client is None:
+            flask.abort(400)
+        id_token = flask.request.values.get('id_token')
+        if flask.request.values.get('code'):
+            token = client.authorize_access_token()
+            if id_token:
+                token['id_token'] = id_token
+        elif id_token:
+            token = {'id_token': id_token}
+
+        # for Google
+        if 'id_token' in token:
+            user_info = client.parse_id_token(token)
+        # for Github
+        else:
+            client.response = client.get('user', token=token)
+            user_info = client.response.json()
+            if user_info['email'] is None:
+                resp = client.get('user/emails', token=token)
+                resp.raise_for_status()
+                data = resp.json()
+                user_info['email'] = next(email['email'] for email in data if email['primary'])
+
+        # Check if the user exists
+        user = User.query.filter(User.email == user_info['email']).first()
+        if not user:
+
+            # TODO: Should create the user (and openid connections) if it does not exist
+            new_user = User(email=user_info['email'], username=user_info['email'])
+            Session.add(new_user)
+            Session.commit()
+            user = new_user
+        flask_login.login_user(user)
+
+        # TODO: Process next not to just redirect with the main page
+        return flask.redirect('/')
+
+    return oauth_blueprint

--- a/anitya/authentication.py
+++ b/anitya/authentication.py
@@ -22,13 +22,12 @@ This module provides functions and classes for authentication and authorization.
 Anitya uses `Flask-Login`_ for user session management. It handles logging in,
 logging out, and remembering users’ sessions over extended periods of time.
 
-In addition, Anitya uses `Python Social Auth`_ to authenticate users from various
+In addition, Anitya uses `Authlib`_ to authenticate users from various
 third-party identity providers. It handles logging the user in and creating
 :class:`anitya.db.models.User` objects as necessary.
 
 .. _Flask-Login: https://flask-login.readthedocs.io/en/latest/
-.. _Python Social Auth:
-    https://python-social-auth.readthedocs.io/en/latest/
+.. _Authlib: https://docs.authlib.org/en/latest/
 """
 from functools import wraps
 import logging

--- a/anitya/config.py
+++ b/anitya/config.py
@@ -66,32 +66,27 @@ DEFAULTS = dict(
     EMAIL_ERRORS=False,
     BLACKLISTED_USERS=[],
     SESSION_PROTECTION="strong",
-    SOCIAL_AUTH_AUTHENTICATION_BACKENDS=(
-        "social_core.backends.fedora.FedoraOpenId",
-        "social_core.backends.gitlab.GitLabOAuth2",
-        "social_core.backends.github.GithubOAuth2",
-        "social_core.backends.google.GoogleOAuth2",
-        "social_core.backends.open_id.OpenIdAuth",
-    ),
-    SOCIAL_AUTH_STORAGE="social_flask_sqlalchemy.models.FlaskStorage",
-    SOCIAL_AUTH_USER_MODEL="anitya.db.models.User",
-    # Force the application to require HTTPS on authentication redirects.
-    SOCIAL_AUTH_REDIRECT_IS_HTTPS=True,
-    SOCIAL_AUTH_LOGIN_URL="/login/",
-    SOCIAL_AUTH_LOGIN_REDIRECT_URL="/",
-    SOCIAL_AUTH_LOGIN_ERROR_URL="/login-error/",
     LIBRARIESIO_PLATFORM_WHITELIST=[],
     DEFAULT_REGEX=r"(?i)%(name)s(?:[-_]?(?:minsrc|src|source))?[-_]([^-/_\s]+?(?:[-_]"
     r"(?:rc|devel|dev|alpha|beta)\d+)?)(?:[-_](?:minsrc|src|source|asc|release))?"
     r"\.(?:tar|t[bglx]z|tbz2|zip)",
-    # Token for GitHub API
-    GITHUB_ACCESS_TOKEN=None,
     SSE_FEED="http://firehose.libraries.io/events",
     CRON_POOL=10,  # Number of workers for check service
     CHECK_TIMEOUT=600,  # Timeout for check service
     # When this number of failed checks is reached,
     # project will be automatically removed, if no version was retrieved yet
     CHECK_ERROR_THRESHOLD=100,
+    # Enabled authentication backends
+    AUTHLIB_ENABLED_BACKENDS=['Fedora', 'GitHub', 'Google'],
+    # Token for GitHub API
+    GITHUB_ACCESS_TOKEN_URL='https://github.com/login/oauth/access_token',
+    GITHUB_AUTHORIZE_URL='https://github.com/login/oauth/authorize',
+    GITHUB_API_BASE_URL='https://api.github.com/',
+    GITHUB_CLIENT_KWARGS={'scope': 'user:email'},
+    FEDORA_CLIENT_KWARGS={'scope': 'openid email profile'},
+    FEDORA_SERVER_METADATA_URL='https://id.fedoraproject.org/.well-known/openid-configuration',
+    GOOGLE_CLIENT_KWARGS={'scope': 'openid email profile'},
+    GOOGLE_SERVER_METADATA_URL='https://accounts.google.com/.well-known/openid-configuration',
 )
 
 # Start with a basic logging configuration, which will be replaced by any user-

--- a/anitya/templates/login.html
+++ b/anitya/templates/login.html
@@ -5,25 +5,8 @@
 {% block body %}
 <div class="socialaccount_ballot">
   <ul class="socialaccount_providers list-inline">
-    {% for name, backend in available_backends.items() %}
-      <li>
-	{% if name == 'openid'%}
-          <form role="form" action="{{url_for('social.auth', backend=name)}}" method="post">
-            <input name="openid_identifier" placeholder="https://id.openid.server">
-            <span class="pull-right">
-                <button type="submit" class="btn btn-success">
-                    <span class="glyphicon glyphicon-plus"></span>
-                    Login</button>
-            </span>
-          </form>
-        {% elif name == 'google-oauth2' %}
-          <a title="{{ Google }}" class="socialaccount_provider openid btn btn-default"
-             href="{{url_for('social.auth', backend=name)}}">Google</a>
-        {% else %}
-          <a title="{{ name.capitalize() }}" class="socialaccount_provider openid btn btn-default"
-             href="{{url_for('social.auth', backend=name)}}">{{ name.capitalize() }}</a>
-        {% endif %}
-      </li>
+    {% for backend in available_backends %}
+    <li><a title="{{ backend }}" class="socialaccount_provider openid btn btn-default" href="{{ url_for('oauth.oauthlogin', name=backend.lower()) }}">{{ backend }}</a></li>
     {% endfor %}
   </ul>
 </div>

--- a/ansible/roles/anitya-dev/tasks/main.yml
+++ b/ansible/roles/anitya-dev/tasks/main.yml
@@ -42,6 +42,7 @@
            fedora-messaging,
            python3-alembic,
            python3-arrow,
+           python-authlib,
            python3-beautifulsoup4,
            python3-dateutil,
            python3-defusedxml,

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ ordered-set>=3.1, <5.0.0
 packaging>=20.0  # (no upper limit, this is a calendar-based version)
 python-dateutil>=2.8.0, <3.0.0
 semver>=2.8.1, <3.0.0
-social-auth-app-flask>=1.0.0, <2.0.0
 social-auth-app-flask-sqlalchemy>=1.0.1, <2.0.0
 sqlalchemy>=1.3.17, <2.0.0
 sseclient>=0.0.26, <1.0.0


### PR DESCRIPTION
Allow authentication with Fedora, GitHub and Google.
This PR aims to get rid of the social_auth library and use authlib instead.

Related issue #1139 