### PR TITLE
Update mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,12 +1,16 @@
+queue_rules:
+  - name: default
+    condition:
+      - check-success=fedora/check
+
 pull_request_rules:
+  name: default
 - actions:
-    merge:
+    queue:
       method: rebase
-      rebase_fallback: null
-      strict: true
+      name: default
   conditions:
   - label!=no-mergify
   - '#approved-reviews-by>=1'
   - check-success=fedora/check
-  name: default
 


### PR DESCRIPTION
Because strict mode is now deprecated, let's use queue instead
https://blog.mergify.com/strict-mode-deprecation/

Signed-off-by: Michal Konečný <mkonecny@redhat.com>