### PR TITLE
Only include unyanked crate versions

### DIFF
--- a/anitya/lib/backends/crates.py
+++ b/anitya/lib/backends/crates.py
@@ -214,7 +214,8 @@ class CratesBackend(BaseBackend):
                 was in an unexpected format.
         """
         filtered_versions = cls.filter_versions(
-            [v["num"] for v in cls._get_versions(project)], project.version_filter
+            [v["num"] for v in cls._get_versions(project) if not v["yanked"]],
+            project.version_filter,
         )
         return filtered_versions
 

--- a/news/PR1272.bug
+++ b/news/PR1272.bug
@@ -1,0 +1,1 @@
+Only include unyanked crate versions


### PR DESCRIPTION
crates.io allows maintainers to "yank" a crate.  When this happens, the crates backend should not include the yanked version.

https://doc.rust-lang.org/cargo/commands/cargo-yank.html