### PR TITLE
Send message every time a new version is retrieved

### DIFF
--- a/news/1273.bug
+++ b/news/1273.bug
@@ -1,0 +1,1 @@
+Intermediate versions are skipped while update checking


### PR DESCRIPTION
Till now we only sent message when the new version was considered
newest. With this commit the logic is changing and we will send the
update message with every retrieved version.

Fixes #1273

Signed-off-by: Michal Konečný <mkonecny@redhat.com>