### PR TITLE
Fix thread timeout during check for new versions

### DIFF
--- a/anitya/lib/utilities.py
+++ b/anitya/lib/utilities.py
@@ -145,9 +145,10 @@ def check_project_release(project, session, test=False):
         project.logs = "No new version found"
 
     if test:
+        session.close()
         return upstream_versions[::-1]
 
-    if not test and upstream_versions:
+    if upstream_versions:
         publish_message(
             project=project.__json__(),
             topic="project.version.update",
@@ -179,8 +180,8 @@ def check_project_release(project, session, test=False):
             ),
         )
 
-        session.add(project)
-        session.commit()
+    session.add(project)
+    session.commit()
 
 
 def create_project(

--- a/news/1284.bug
+++ b/news/1284.bug
@@ -1,0 +1,1 @@
+Thread timeout in check_service


### PR DESCRIPTION
Session.commit() needs to be called every time there isn't any test run
not only if there are new versions found.

Fixes #1284

Signed-off-by: Michal Konečný <mkonecny@redhat.com>