### PR TITLE
Add support for python 3.10

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,5 @@
+version: 2
+
+build:
+  tools:
+    python: "3.10"

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -94,6 +94,27 @@
         label: cloud-fedora-35
 
 - job:
+    name: tox-python310
+    description: |
+      Run unit tests for a Python project under cPython version 3.10.
+
+      Uses tox with the ``py310`` environment.
+      
+      Ensures that the python310 interpreter is installed.
+
+    parent: tox
+    run: ci/test-tox.yaml
+    vars:
+      tox_env: py310
+      job_dependencies:
+        - tox
+        - python310
+    nodeset:
+      nodes:
+        name: test-node
+        label: cloud-fedora-35
+
+- job:
     name: anitya-tox-docs
     description: |
       Build docs in tox specifically for anitya.
@@ -161,6 +182,7 @@
         - tox-format
         - tox-python38
         - tox-python39
+        - tox-python310
         - anitya-tox-docs
         - tox-bandit
         - tox-diff-cover

--- a/news/1300.dev
+++ b/news/1300.dev
@@ -1,0 +1,1 @@
+Add support for Python 3.10

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     python_requires=">=3.8",
     packages=find_packages(exclude=["anitya.tests", "anitya.tests.*"]),

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = mypy,py38,py39,diff-cover,lint,format,bandit,docs
+envlist = mypy,py38,py39,py310,diff-cover,lint,format,bandit,docs
 
 [testenv]
 passenv = TRAVIS TRAVIS_*


### PR DESCRIPTION
This commit will add support for python 3.10 to ReadTheDocs build, tox
environment and Zuul CI.

Closes #1300

Signed-off-by: Michal Konečný <mkonecny@redhat.com>