### PR TITLE
Use build setting instead of python

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,11 +6,10 @@ formats:
   - pdf
 
 # Python configuration
-python:
-  version: "3.10"
-  install:
-    - requirements: requirements.txt
-    - requirements: test_requirements.txt
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
 
 # Sphinx configuration
 sphinx:


### PR DESCRIPTION
python.version setting is now deprecated and build.tools.python should be used instead.