### PR TITLE
Fix CI tests

### DIFF
--- a/anitya/tests/test_flask.py
+++ b/anitya/tests/test_flask.py
@@ -486,14 +486,14 @@ class FlaskTest(DatabaseTestCase):
         with login_user(self.flask_app, self.user):
             output = self.app.get("/")
             self.assertEqual(output.status_code, 302)
-            self.assertEqual(output.headers["Location"], "http://localhost/project/1")
+            self.assertEqual(output.headers["Location"], "/project/1")
 
     def test_about(self):
         """Assert the legacy about endpoint redirects to documentation"""
         output = self.app.get("/about")
         self.assertEqual(output.status_code, 302)
         self.assertEqual(
-            output.headers["Location"], "http://localhost/static/docs/index.html"
+            output.headers["Location"], "/static/docs/index.html"
         )
 
     def test_project(self):
@@ -710,7 +710,7 @@ class FlaskTest(DatabaseTestCase):
         with login_user(self.flask_app, self.user):
             output = self.app.get("/logout")
             self.assertEqual(output.status_code, 302)
-            self.assertEqual(output.headers["Location"], "http://localhost/")
+            self.assertEqual(output.headers["Location"], "/")
 
     def test_logout(self):
         """Assert the logout logouts user"""

--- a/anitya/tests/test_flask_api.py
+++ b/anitya/tests/test_flask_api.py
@@ -60,7 +60,7 @@ class AnityaWebAPItests(DatabaseTestCase):
         output = self.app.get("/api")
         self.assertEqual(302, output.status_code)
         self.assertEqual(
-            "http://localhost/static/docs/api.html", output.headers["Location"]
+            "/static/docs/api.html", output.headers["Location"]
         )
 
     def test_api_docs_with_slash(self):
@@ -68,7 +68,7 @@ class AnityaWebAPItests(DatabaseTestCase):
         output = self.app.get("/api/")
         self.assertEqual(302, output.status_code)
         self.assertEqual(
-            "http://localhost/static/docs/api.html", output.headers["Location"]
+            "/static/docs/api.html", output.headers["Location"]
         )
 
     def test_api_projects(self):


### PR DESCRIPTION
The location in headers now only contains the relative location. This commit is
addressing this change.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>