### PR TITLE
Clean vagrant dev environment

### DIFF
--- a/ansible/roles/anitya-dev/tasks/main.yml
+++ b/ansible/roles/anitya-dev/tasks/main.yml
@@ -76,7 +76,6 @@
   pip:
     name:
       - "{{ anitya_src }}"
-      - "{{ anitya_src }}/anitya_schema"
     extra_args: "-e"
   tags: install
 


### PR DESCRIPTION
Remove message schema installation from vagrant ansible playbook. Message schema
is now in separate repository and will be installed by pip.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>