### PR TITLE
Add dependabot rule to mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,3 +14,12 @@ pull_request_rules:
     - '#approved-reviews-by>=1'
     - check-success=fedora/check
 
+  - name: dependabot
+    actions:
+      queue:
+        method: rebase
+        name: default
+    conditions:
+    - author=dependabot
+    - label!=no-mergify
+    - check-success=fedora/check


### PR DESCRIPTION
Dependabot PRs don't need to wait for review if they pass CI.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>