### PR TITLE
Fix internal server error on some projects with RPM version scheme

### DIFF
--- a/anitya/check_service.py
+++ b/anitya/check_service.py
@@ -119,7 +119,10 @@ class Checker:
                     message=dict(agent="anitya", project=project.name),
                 )
                 session.commit()
+            session.close()
             return
+        finally:
+            session.close()
 
         with self.success_counter_lock:
             self.success_counter += 1

--- a/anitya/lib/versions/rpm.py
+++ b/anitya/lib/versions/rpm.py
@@ -132,7 +132,7 @@ class RpmVersion(Version):
                 is one of (rc, pre, beta, alpha, dev).
         """
         match = cls._rc_upstream_regex.match(version)
-        if not match:
+        if not match or not match.group(1):
             return (version, "", "")
 
         return (match.group(1), match.group(3), match.group(4))

--- a/anitya/tests/lib/versions/test_rpm.py
+++ b/anitya/tests/lib/versions/test_rpm.py
@@ -210,6 +210,16 @@ class RpmVersionTests(unittest.TestCase):
         self.assertTrue(old_version < new_version)
         self.assertFalse(new_version < old_version)
 
+    def test_lt_nonsense_version(self):
+        """
+        Assert nonsense version is less than right one.
+        See https://github.com/fedora-infra/anitya/issues/1390
+        """
+        old_version = rpm.RpmVersion(version="prerelease")
+        new_version = rpm.RpmVersion(version="1.1.0")
+        self.assertTrue(old_version < new_version)
+        self.assertFalse(new_version < old_version)
+
     def test_le(self):
         """Assert RpmVersion supports <= comparison."""
         old_version = rpm.RpmVersion(version="v1.0.0")

--- a/news/1390.bug
+++ b/news/1390.bug
@@ -1,0 +1,1 @@
+Internal server errors occurring at release-monitoring


### PR DESCRIPTION
This error was caused by nonsense version which unfortunately matched the rpm
regex. This wasn't issue before, because we used our own implementation of
compare method, but now we can use the one from RPM library.

The solution to this was to make sure that the version we are trying to compare
is not an empty string.

Second thing that was part of this internal server error issue and caused a lot
of mess in whole infra are the hanging connection to database when the above
error occurs. So this commit makes sure that the session is always closed during
check_service execution.

Fixes #1390.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>