### PR TITLE
Don't compare empty version strings in RPM

### DIFF
--- a/anitya/lib/versions/rpm.py
+++ b/anitya/lib/versions/rpm.py
@@ -159,7 +159,11 @@ class RpmVersion(Version):
         support.
         """
         v1, rc1, rcn1 = self.split_rc(self.parse())
+        if not v1:
+            return False
         v2, rc2, rcn2 = self.split_rc(other.parse())
+        if not v2:
+            return False
         result = _compare_rpm_labels((None, v1, None), (None, v2, None))
         if result != 0:
             return False
@@ -171,7 +175,11 @@ class RpmVersion(Version):
 
     def __lt__(self, other):
         v1, rc1, rcn1 = self.split_rc(self.parse())
+        if not v1:
+            return True
         v2, rc2, rcn2 = self.split_rc(other.parse())
+        if not v2:
+            return False
         result = _compare_rpm_labels((None, v1, None), (None, v2, None))
         if result == -1:
             return True

--- a/anitya/tests/lib/versions/test_rpm.py
+++ b/anitya/tests/lib/versions/test_rpm.py
@@ -210,6 +210,13 @@ class RpmVersionTests(unittest.TestCase):
         self.assertTrue(old_version < new_version)
         self.assertFalse(new_version < old_version)
 
+    def test_lt_empty_version(self):
+        """Assert that empty version is handled correctly."""
+        old_version = rpm.RpmVersion(version="")
+        new_version = rpm.RpmVersion(version="v1.1.0rc1")
+        self.assertTrue(old_version < new_version)
+        self.assertFalse(new_version < old_version)
+
     def test_lt_nonsense_version(self):
         """
         Assert nonsense version is less than right one.
@@ -262,3 +269,10 @@ class RpmVersionTests(unittest.TestCase):
         old_version = rpm.RpmVersion(version="v1.0.0-1.fc26")
         new_version = rpm.RpmVersion(version="1.0.0-1.fc26")
         self.assertTrue(new_version == old_version)
+
+    def test_eq_empty_version(self):
+        """Assert empty version is handled correctly."""
+        old_version = rpm.RpmVersion(version="")
+        new_version = rpm.RpmVersion(version="v1.0.0")
+        self.assertTrue(new_version != old_version)
+        self.assertTrue(old_version != new_version)


### PR DESCRIPTION
RPM library _compare_rpm_labels function doesn't handle empty string as input.
Let's ensure empty string is handled before the function is called.

Fixes #1390.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>