### PR TITLE
Skip empty versions during check

### DIFF
--- a/anitya/lib/utilities.py
+++ b/anitya/lib/utilities.py
@@ -119,6 +119,9 @@ def check_project_release(project, session, test=False):
     upstream_versions = []
     for version in versions:
         if version not in p_versions:
+            if not version.version:
+                # Skip empty version
+                continue
             if len(version.version) < version_column_len:
                 project.versions_obj.append(
                     models.ProjectVersion(

--- a/news/PR1401.bug
+++ b/news/PR1401.bug
@@ -1,0 +1,1 @@
+Empty versions obtained for some projects


### PR DESCRIPTION
In some projects I noticed that they are empty strings as versions. Let's
prevent this behavior in the future by skipping empty strings during the check
for new versions.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>