### PR TITLE
project templates: add mapping to launchpad for Ubuntu packages

### DIFF
--- a/anitya/templates/project.html
+++ b/anitya/templates/project.html
@@ -199,6 +199,10 @@
                       <a href="https://github.com/pld-linux/{{ package.package_name }}">
                         {{ package.package_name }}
                       </a>
+                    {% elif package.distro_name == 'Ubuntu' %}
+                      <a href="https://launchpad.net/ubuntu/+source/{{ package.package_name }}">
+                        {{ package.package_name }}
+                      </a>
                     {% else %}
                       {{ package.package_name }}
                     {% endif %}

--- a/news/PR1403.feature
+++ b/news/PR1403.feature
@@ -1,0 +1,1 @@
+Add Ubuntu links to project page.


### PR DESCRIPTION
Source packages in Ubuntu are tracked and visible via the URL pattern:

  https://launchpad.net/ubuntu/+source/{package_name}

[There is also a REST API briefly documented at
 https://help.launchpad.net/API ]

Signed-off-by: Steve Beattie <steve.beattie@canonical.com>