### PR TITLE
Fix regex for folder backend

### DIFF
--- a/anitya/lib/backends/folder.py
+++ b/anitya/lib/backends/folder.py
@@ -12,7 +12,7 @@ from anitya.lib.backends import BaseBackend, get_versions_by_regex_for_text, REG
 from anitya.lib.exceptions import AnityaPluginException
 import six
 
-DEFAULT_REGEX = 'href="(?:/files/)?([0-9.]+.*)/"'
+DEFAULT_REGEX = 'href="(?:/files/)?([0-9][0-9.]+.*)/"'
 
 
 class FolderBackend(BaseBackend):

--- a/news/1286.bug
+++ b/news/1286.bug
@@ -1,0 +1,1 @@
+Folder backend returns wrong version


### PR DESCRIPTION
In current state the regex was matching even versions that were not a
version (for example `..`). This commit is fixing the regex to always assume
that the first character is number.

Fixes #1286

Signed-off-by: Michal Konečný <mkonecny@redhat.com>