### PR TITLE
fix get_version_url in github backend

### DIFF
--- a/anitya/lib/backends/github.py
+++ b/anitya/lib/backends/github.py
@@ -88,7 +88,9 @@ class GithubBackend(BaseBackend):
             url = url[:-1]
 
         if url:
-            url = "https://github.com/{}/tags".format(url)
+            url_template = "https://github.com/%(repo)s/%(release_or_tag)s"
+            release_or_tag = "releases" if project.releases_only else "tags"
+            return url_template % {"repo": url, "release_or_tag": release_or_tag}
 
         return url
 
@@ -155,7 +157,8 @@ class GithubBackend(BaseBackend):
         url = cls.get_version_url(project)
         if url:
             url = url.replace("https://github.com/", "")
-            url = url.replace("/tags", "")
+            url = url.rstrip("/tags")
+            url = url.rstrip("/releases")
         else:
             raise AnityaPluginException(
                 "Project %s was incorrectly set up." % project.name

--- a/anitya/tests/lib/backends/test_github.py
+++ b/anitya/tests/lib/backends/test_github.py
@@ -257,6 +257,44 @@ class GithubBackendtests(DatabaseTestCase):
 
         self.assertEqual(obs, exp)
 
+    def test_get_version_url_project_releases_only(self):
+        """
+        Assert that correct url is returned when
+        releases_only is marked
+        """
+        project = models.Project(
+            name="test",
+            homepage="https://github.com/test/test",
+            backend=BACKEND,
+            releases_only=True,
+        )
+        exp = "https://github.com/test/test/releases"
+        obs = backend.GithubBackend.get_version_url(project)
+        self.assertEqual(obs, exp)
+
+    def test_get_version_url_project_version_url_contains_tags(self):
+        """
+        Assert that correct url is returned when
+        version_url contains tags
+        """
+        project = models.Project(
+            name="Tags Repository", version_url="fedora-infra/tags", backend=BACKEND
+        )
+        exp = "https://github.com/fedora-infra/tags/tags"
+        obs = backend.GithubBackend.get_version_url(project)
+        self.assertEqual(obs, exp)
+
+    def test_get_version_url_project_version_url_contains_releases(self):
+        project = models.Project(
+            name="Releases Repository",
+            version_url="fedora-infra/releases",
+            backend=BACKEND,
+            releases_only=True,
+        )
+        exp = "https://github.com/fedora-infra/releases/releases"
+        obs = backend.GithubBackend.get_version_url(project)
+        self.assertEqual(obs, exp)
+
     def test_get_version_url_homepage_slash(self):
         """
         Assert that correct url is returned when

--- a/news/1013.bug
+++ b/news/1013.bug
@@ -1,0 +1,1 @@
+Fixed version check url for GitHub projects those marked with "Check releases instead of tags"


### PR DESCRIPTION
Resolves: #1013 

Also while i was fixing bug that mentioned in #1013 , i noticed that "/tags" value is always replaced by "" https://github.com/fedora-infra/anitya/blob/c94a0b4088fe4542c7cf7d483bd1beffd4b2154c/anitya/lib/backends/github.py#L158. This can lead to problems if given project's owner or repo name is "tags".  In order to prevent this problem, i've replaced `url.replace("/tags", "")` with `url.rstrip("/tags")`. Also added tests for it. 