### PR TITLE
Fix version scheme field value disappearing

### DIFF
--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -307,7 +307,7 @@
     if ($('#name').val()) {
       temp = temp.replace('{project name}', $('#name').val());
     }
-    if (default_version_plugin[str]) {
+    if (default_version_plugin[str] && !$(`#version_scheme`).val()) {
       $('#version_scheme').val("default_version_plugin[str]");
     }
     $('#regex_example_txt').html('<div id="default_regex_txt">' + temp + '</div>');

--- a/news/1389.bug
+++ b/news/1389.bug
@@ -1,0 +1,1 @@
+Saved "Version scheme" value is not loaded


### PR DESCRIPTION
The field got replaced by the default backend value each time the page was
loaded. Checking if the value is filled already before replacing it helps.

Fixes #1389

Signed-off-by: Michal Konečný <mkonecny@redhat.com>