### PR TITLE
Make links to package sources configurable

### DIFF
--- a/anitya/config.py
+++ b/anitya/config.py
@@ -92,6 +92,7 @@ DEFAULTS = dict(
     # When this number of failed checks is reached,
     # project will be automatically removed, if no version was retrieved yet
     CHECK_ERROR_THRESHOLD=100,
+    DISTRO_MAPPING_LINKS={},
 )
 
 # Start with a basic logging configuration, which will be replaced by any user-

--- a/anitya/templates/project.html
+++ b/anitya/templates/project.html
@@ -187,20 +187,8 @@
                 <tr>
                   <td>{{ package.distro_name }}</td>
                   <td>
-                    {% if package.distro_name == 'AlmaLinux' %}
-                      <a href="https://git.almalinux.org/rpms/{{ package.package_name }}">
-                        {{ package.package_name }}
-                      </a>                    
-                    {% elif package.distro_name == 'Fedora' %}
-                      <a href="https://src.fedoraproject.org/rpms/{{ package.package_name }}">
-                        {{ package.package_name }}
-                      </a>
-                    {% elif package.distro_name == 'PLD-Linux' %}
-                      <a href="https://github.com/pld-linux/{{ package.package_name }}">
-                        {{ package.package_name }}
-                      </a>
-                    {% elif package.distro_name == 'Ubuntu' %}
-                      <a href="https://launchpad.net/ubuntu/+source/{{ package.package_name }}">
+                    {% if package.distro_name in links %}
+                      <a href="{{ links.get(package.distro_name) % package.package_name}}">
                         {{ package.package_name }}
                       </a>
                     {% else %}

--- a/anitya/tests/test_config.py
+++ b/anitya/tests/test_config.py
@@ -55,7 +55,12 @@ sse_feed = "http://firehose.libraries.io/events"
 
 default_regex = "a*b*"
 github_access_token = "foobar"
-legacy_messaging = true
+
+[distro_mapping_links]
+AlmaLinux = "https://git.almalinux.org/rpms/%s"
+Fedora = "https://src.fedoraproject.org/rpms/%s"
+PLD-Linux = "https://github.com/pld-linux/%s"
+Ubuntu = "https://launchpad.net/ubuntu/+source/%s"
 
 [anitya_log_config]
     version = 1
@@ -170,11 +175,16 @@ class LoadTests(unittest.TestCase):
             "LIBRARIESIO_PLATFORM_WHITELIST": ["pypi", "rubygems"],
             "DEFAULT_REGEX": "a*b*",
             "GITHUB_ACCESS_TOKEN": "foobar",
-            "LEGACY_MESSAGING": True,
             "SSE_FEED": "http://firehose.libraries.io/events",
             "CRON_POOL": 10,
             "CHECK_TIMEOUT": 600,
             "CHECK_ERROR_THRESHOLD": 100,
+            "DISTRO_MAPPING_LINKS": {
+                "AlmaLinux": "https://git.almalinux.org/rpms/%s",
+                "Fedora": "https://src.fedoraproject.org/rpms/%s",
+                "PLD-Linux": "https://github.com/pld-linux/%s",
+                "Ubuntu": "https://launchpad.net/ubuntu/+source/%s",
+            },
         }
         config = anitya_config.load()
         self.assertEqual(sorted(expected_config.keys()), sorted(config.keys()))

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -6,6 +6,7 @@ from flask_login import login_required, logout_user, current_user
 import flask
 from sqlalchemy.exc import SQLAlchemyError
 
+from anitya.config import config as anitya_config
 from anitya.db import Session, models
 from anitya.lib import utilities, exceptions, plugins as anitya_plugins
 import anitya
@@ -108,7 +109,12 @@ def project(project_id):
     if not project:
         flask.abort(404)
 
-    return flask.render_template("project.html", current="project", project=project)
+    return flask.render_template(
+        "project.html",
+        current="project",
+        project=project,
+        links=anitya_config.get("DISTRO_MAPPING_LINKS", {}),
+    )
 
 
 @ui_blueprint.route("/project/<project_name>")

--- a/files/anitya.toml.sample
+++ b/files/anitya.toml.sample
@@ -76,6 +76,15 @@ check_timeout = 600
 # project will be automatically removed, if no version was retrieved yet
 check_error_threshold=100
 
+# Configurable links to package repositories for package mappings in distributions
+# If you want to add any new distribution just add a new entry to this section
+# %s will be filled in HTML template by the name of package mapping
+[distro_mapping_links]
+AlmaLinux = "https://git.almalinux.org/rpms/%s"
+Fedora = "https://src.fedoraproject.org/rpms/%s"
+PLD-Linux = "https://github.com/pld-linux/%s"
+Ubuntu = "https://launchpad.net/ubuntu/+source/%s"
+
 # The logging configuration, in Python dictConfig format.
 [anitya_log_config]
     version = 1

--- a/news/1066.feature
+++ b/news/1066.feature
@@ -1,0 +1,1 @@
+Add configuration for distro links


### PR DESCRIPTION
Add new configuration section [distro_mapping_links] that contains template for links for various distributions.

Closes #1066

Signed-off-by: Michal Konečný <mkonecny@redhat.com>