### PR TITLE
Add package rule for Werkzeug for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,11 @@
   ],
   "docker": {
       "enabled": false
-  }
+  },
+  "packageRules": [
+      {
+        "mactchPackageNames": ["Werkzeug"],
+        "groupName": null
+      }
+  ]
 }


### PR DESCRIPTION
To prevent having Werkzeug as part of group PR let's create a separate package rule for it in Renovate.

The newer Werkzeug is currently failing documentation builds and there is no easy way to solve this. We need to wait for upstream to fix this.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>