### PR TITLE
Pin the minimum version of Jinja2 to 3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,8 +92,8 @@ fedora-messaging = "^3.1.0"
 Flask = "^2.1.2"
 Flask-Login = "^0.6.2"
 Flask-WTF = "^1.0.1"
-# Pin the Jinja2 version to fix the issue https://github.com/sphinx-doc/sphinx/issues/10306
-Jinja2 = "3.1.0"
+# ReadTheDocs build environment has version of Jinja2 3.0.3 currently
+Jinja2 = "^3.0.0"
 ordered-set = "^4.1.0"
 packaging = "^21.3"
 python-dateutil = "^2.8.2"


### PR DESCRIPTION
ReadTheDocs has currently version 3.0.3 which the build works with. Let's change the minimum to 3.0.0 so the version in ReadTheDocs build environment is used.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>