### PR TITLE
Update readthedocs configuration with poetry

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,17 +5,16 @@ formats:
   - epub
   - pdf
 
-# Python install configuration
-python:
-  install:
-    - method: pip
-      path: .
-
 # Build configuration
 build:
   os: ubuntu-20.04
   tools:
     python: "3.10"
+  jobs:
+    post_install:
+      - pip install poetry
+      - poetry config virtualenvs.create false
+      - poetry intall
 
 # Sphinx configuration
 sphinx:


### PR DESCRIPTION
Use post_install job in readthedocs.yaml to use poetry for installing app instead of pip. This will install dev requirements as well as app itself.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>