### PR TITLE
Migrate MANIFEST.in to pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,0 @@
-include LICENSE README.rst
-include runtests.sh createdb.py alembic.ini
-include requirements.txt readthedocs.txt test_requirements.txt
-recursive-include files *
-recursive-include anitya/templates *
-recursive-include anitya/static *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,15 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10"
 ]
-exclude = ["anitya/tests"]
+exclude = [
+  "anitya/tests"
+]
+include = [
+  "LICENSE", "README.rst",
+  "createdb.py", "alembic.ini",
+  "files/anitya.toml.sample", "files/config.toml.sample",
+  "anitya/templates/", "anitya/static"
+]
 
 [tool.poetry.scripts]
 check_service = "anitya.check_service:main"


### PR DESCRIPTION
The final package created by poetry didn't include some of the files. I forgot that those were defined in MANIFEST.in which is not used by poetry. Poetry instead uses include argument in configuration.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>