### PR TITLE
Fix the poetry setup in container dev environment

### DIFF
--- a/.container/consumer/motd
+++ b/.container/consumer/motd
@@ -6,10 +6,10 @@ Here are some tips:
 * The code is located at /app
 
 * To run libraries.io service simply run
-librariesio_consumer.py
+librariesio_consumer
 
 * To run check service simply run
-check_service.py
+check_service
 
 Happy hacking!
 

--- a/.container/web/motd
+++ b/.container/web/motd
@@ -5,14 +5,13 @@ Here are some tips:
 
 * The code is located at /app
 
-* Start the development server with
-FLASK_APP=anitya.wsgi flask run
+The development server is running on http://localhost:5000/.
 
-Once you start the development server, you can navigate to http://localhost:5000/
-in your host's browser.
+* To start check service simply run `check_service`
 
-* To run check service simply run
-check_service.py
+* To start tests run `tox`
+
+* To apply changes run `make restart` outside the container
 
 Happy hacking!
 

--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -19,7 +19,7 @@ RUN dnf autoremove -y && dnf clean all -y
 COPY anitya ./anitya
 COPY ansible ./ansible
 COPY .container ./.container
-COPY alembic.ini anitya.wsgi createdb.py pyproject.toml tox.ini README.rst .
+COPY mypy.cfg alembic.ini anitya.wsgi createdb.py pyproject.toml tox.ini README.rst poetry.lock .
 
 # Copy over configuration files
 RUN mkdir -p /etc/anitya
@@ -27,12 +27,12 @@ RUN cp /app/ansible/roles/anitya-dev/files/anitya.toml /etc/anitya
 RUN mkdir -p /etc/fedora-messaging
 RUN cp /app/.container/web/config.toml /etc/fedora-messaging
 
-# Pip installations
-RUN poetry config virtualenvs.create false
-RUN poetry install
+# Poetry installation
+RUN poetry build
+RUN pip install dist/*.whl
 
 # Hotfix for social_auth-sqlalchemy
 # Should be removed when we switch to something else
 RUN sed -i 's/base64.encodestring/base64.encodebytes/g' /usr/local/lib/python3.10/site-packages/social_sqlalchemy/storage.py
 
-CMD ["sh","-c", "poetry install && eval '$START_COMMAND'"]
+CMD ["sh","-c", "poetry build && pip install dist/*.whl && eval '$START_COMMAND'"]

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -12,7 +12,8 @@ services:
     ports:
       - "127.0.0.1:5000:5000"
     volumes:
-      - ./:/app:z
+      - ./anitya/:/app/anitya:z
+      - ./docs/:/app/docs:z
     restart: unless-stopped
     environment:
       - FLASK_APP=anitya.wsgi
@@ -32,10 +33,11 @@ services:
         FEDORA_VERSION: 36
     container_name: "anitya-librariesio-consumer"
     volumes:
-      - ./:/app:z
+      - ./anitya/:/app/anitya:z
+      - ./docs/:/app/docs:z
     restart: unless-stopped
     environment:
-      - START_COMMAND=librariesio_consumer.py
+      - START_COMMAND=librariesio_consumer
     depends_on:
       postgres:
         condition: service_started

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -230,20 +230,17 @@ Makefile scripts that provide easier container management:
 
 Project files are bound to each other with host and container. Whenever you change any project file from the host or the container, the same change will happen on the opposite side as well.
 
-Start the development web server included with Flask with::
-
-    $ make bash-web
-    $ FLASK_APP=anitya.wsgi flask run
-
-Start the libraries.io service with::
-
-    $ make bash-consumer
-    $ librariesio_consumer.py
+Anitya is accessible on http://localhost:5000
 
 Start the check service with::
 
     $ make bash-consumer or make-bash-web
     $ check_service.py
+
+To apply changes run::
+    $ make restart
+
+This will restart the container, deploy the changes in code and start the development instance again.
 
 Python virtualenv
 -----------------


### PR DESCRIPTION
Switching to poetry did introduce some issues to container development environment. Now it is not possible to easily install application in editable mode and you need to restart the container on each change. Updated the documenation to reflect that.

Also fixed names of scripts and updated MOTD for containers.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>