### PR TITLE
Use the newer version of `anitya.project.version.remove` topic

### DIFF
--- a/anitya/admin.py
+++ b/anitya/admin.py
@@ -282,9 +282,11 @@ def delete_project_version(project_id, version):
         if confirm:
             utilities.publish_message(
                 project=project.__json__(),
-                topic="project.version.remove",
+                topic="project.version.remove.v2",
                 message=dict(
-                    agent=flask.g.user.username, project=project.name, version=version
+                    agent=flask.g.user.username,
+                    project=project.name,
+                    versions=[version],
                 ),
             )
 

--- a/anitya/tests/test_flask_admin.py
+++ b/anitya/tests/test_flask_admin.py
@@ -685,7 +685,7 @@ class DeleteProjectVersionTests(DatabaseTestCase):
             ].split(b'">')[0]
             data = {"confirm": True, "csrf_token": csrf_token}
 
-            with fml_testing.mock_sends(anitya_schema.ProjectVersionDeleted):
+            with fml_testing.mock_sends(anitya_schema.ProjectVersionDeletedV2):
                 output = self.client.post(
                     "/project/1/delete/1.0.0", data=data, follow_redirects=True
                 )
@@ -707,7 +707,7 @@ class DeleteProjectVersionTests(DatabaseTestCase):
             ].split(b'">')[0]
             data = {"confirm": True, "csrf_token": csrf_token}
 
-            with fml_testing.mock_sends(anitya_schema.ProjectVersionDeleted):
+            with fml_testing.mock_sends(anitya_schema.ProjectVersionDeletedV2):
                 output = self.client.post(
                     "/project/1/delete/1.0.1", data=data, follow_redirects=True
                 )
@@ -732,7 +732,7 @@ class DeleteProjectVersionTests(DatabaseTestCase):
             ].split(b'">')[0]
             data = {"confirm": True, "csrf_token": csrf_token}
 
-            with fml_testing.mock_sends(anitya_schema.ProjectVersionDeleted):
+            with fml_testing.mock_sends(anitya_schema.ProjectVersionDeletedV2):
                 output = self.client.post(
                     "/project/1/delete/v1.0.1", data=data, follow_redirects=True
                 )
@@ -754,7 +754,7 @@ class DeleteProjectVersionTests(DatabaseTestCase):
             ].split(b'">')[0]
             data = {"confirm": True, "csrf_token": csrf_token}
 
-            with fml_testing.mock_sends(anitya_schema.ProjectVersionDeleted):
+            with fml_testing.mock_sends(anitya_schema.ProjectVersionDeletedV2):
                 output = self.client.post(
                     "/project/1/delete/1.0.0", data=data, follow_redirects=True
                 )

--- a/docs/integrating-with-anitya.rst
+++ b/docs/integrating-with-anitya.rst
@@ -57,7 +57,9 @@ sending and in what situation.
   for the project. This message differentiate between stable and
   not stable releases.
 * *anitya.project.version.remove* is sent when an existing release is
-  deleted from project.
+  deleted from project. This topic is now deprecated.
+* *anitya.project.version.remove.v2* is sent when an existing release is
+  deleted from project. Adds support for batch deletion.
 
 You can found out more about Anitya messages in `Fedora messaging schema`_.
 The schema should be used by every consumer that consumes Anitya messages.

--- a/news/PR1495.other
+++ b/news/PR1495.other
@@ -1,0 +1,1 @@
+Use `anitya.project.version.remove.v2` instead of `anitya.project.version.remove`


### PR DESCRIPTION
With `anitya.project.version.remove.v2` available, let's start using this instead of `anitya.project.version.remove`.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>