### PR TITLE
[#1402] Fix Python versioning parse doesn't return string

### DIFF
--- a/anitya/lib/versions/python.py
+++ b/anitya/lib/versions/python.py
@@ -44,7 +44,7 @@ class PythonVersion(base.Version):
 
     name = "Python (PEP 440)"
 
-    def parse(self):
+    def version_object(self):
         """
         Parse the version string to an object representing the version.
 
@@ -64,12 +64,18 @@ class PythonVersion(base.Version):
         except packaging.version.InvalidVersion as e:
             raise base.InvalidVersion(str(e)) from e
 
+    def parse(self):
+        """
+        Return string representation of the version object
+        """
+        return str(self.version_object())
+
     def prerelease(self):
         """
         Check this is a pre-release version.
         """
         try:
-            parsed = self.parse()
+            ver_obj = self.version_object()
         except base.InvalidVersion:
             return False
 
@@ -77,14 +83,14 @@ class PythonVersion(base.Version):
             if pre_release_filter and pre_release_filter in self.version:
                 return True
 
-        return parsed.is_prerelease
+        return ver_obj.is_prerelease
 
     def postrelease(self):
         """
         Check this is a post-release version.
         """
         try:
-            parsed = self.parse()
+            ver_obj = self.version_object()
         except base.InvalidVersion:
             return False
-        return parsed.is_postrelease
+        return ver_obj.is_postrelease


### PR DESCRIPTION
Bug affects specific version scheme `Python (PEP 440)`

![Bug Example](https://user-images.githubusercontent.com/12795148/206926595-12e8b980-829b-4069-9e42-5830eb6e3a6a.png)

Fix:
Return a string when invoking parse method of the PythonVersion class. When prerelease & postrelease methods are called, Version object is used.

Version handling reference:
https://packaging.pypa.io/en/latest/version.html