### PR TITLE
Fix Containerfile for Fedora 37 / Python 3.11

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -39,6 +39,6 @@ RUN pip install dist/*.whl
 
 # Hotfix for social_auth-sqlalchemy
 # Should be removed when we switch to something else
-RUN sed -i 's/base64.encodestring/base64.encodebytes/g' /usr/local/lib/python3.10/site-packages/social_sqlalchemy/storage.py
+RUN sed -i 's/base64.encodestring/base64.encodebytes/g' /usr/local/lib/python3.*/site-packages/social_sqlalchemy/storage.py
 
 CMD ["sh","-c", "poetry build && pip install dist/*.whl && eval '$START_COMMAND'"]


### PR DESCRIPTION
Fedora 37 has Python 3.11, so the hardcoded path won't work. Verified with Podman 4.3.1

```
STEP 19/21: RUN sed -i 's/base64.encodestring/base64.encodebytes/g' /usr/local/lib/python3.*/site-packages/social_sqlalchemy/storage.py
--> Using cache f4243073de8a091c6a777315ef79d5f7da69cd1ff95aaa32d7237d1f719f8464
--> f4243073de8
STEP 20/21: RUN cat /usr/local/lib/python3.11/site-packages/social_sqlalchemy/storage.py | grep base64
import base64
    secret = Column(String(255))  # base64 encoded
        assoc.secret = base64.encodebytes(association.secret).decode()
```