### PR TITLE
add stable_version as output in PackagesResource

### DIFF
--- a/anitya/api_v2.py
+++ b/anitya/api_v2.py
@@ -125,7 +125,8 @@ class PackagesResource(MethodView):
                         "name": "python-requests"
                         "project": "requests",
                         "ecosystem": "pypi",
-                        "version": "2.28.1"
+                        "version": "2.28.1",
+                        "stable_version": "2.28.1"
                     }
                 ],
                 "items_per_page": 25,
@@ -168,6 +169,7 @@ class PackagesResource(MethodView):
                     "project": package.project.name,
                     "ecosystem": package.project.ecosystem_name,
                     "version": package.project.latest_version,
+                    "stable_version": package.project.latest_stable_version,
                 }
                 for package in page.items
             ],

--- a/anitya/db/models.py
+++ b/anitya/db/models.py
@@ -304,6 +304,19 @@ class Project(Base):
         sorted_versions = self.get_sorted_version_objects()
         return [version for version in sorted_versions if not version.prerelease()]
 
+    @property
+    def latest_stable_version(self):
+        """
+        Return latest stable version.
+
+        Returns:
+           `string`: Latest stable version if exists, otherwise None.
+        """
+        stable_versions = self.stable_versions
+        if stable_versions:
+            return str(stable_versions[0])
+        return None
+
     def get_last_created_version(self):
         """
         Returns last obtained release by date.

--- a/anitya/tests/test_flask_api_v2.py
+++ b/anitya/tests/test_flask_api_v2.py
@@ -101,7 +101,10 @@ class PackagesResourceGetTests(DatabaseTestCase):
         jcline_package = models.Packages(
             distro_name="jcline linux", project=project, package_name="requests"
         )
-        Session.add_all([project, fedora_package, debian_package, jcline_package])
+        version = models.ProjectVersion(project=project, version="1")
+        Session.add_all(
+            [project, fedora_package, debian_package, jcline_package, version]
+        )
         Session.commit()
 
         output = self.app.get("/api/v2/packages/")
@@ -119,6 +122,7 @@ class PackagesResourceGetTests(DatabaseTestCase):
                     "project": "requests",
                     "ecosystem": "pypi",
                     "version": "1",
+                    "stable_version": "1",
                 },
                 {
                     "distribution": "Debian",
@@ -126,6 +130,7 @@ class PackagesResourceGetTests(DatabaseTestCase):
                     "project": "requests",
                     "ecosystem": "pypi",
                     "version": "1",
+                    "stable_version": "1",
                 },
                 {
                     "distribution": "jcline linux",
@@ -133,6 +138,7 @@ class PackagesResourceGetTests(DatabaseTestCase):
                     "project": "requests",
                     "ecosystem": "pypi",
                     "version": "1",
+                    "stable_version": "1",
                 },
             ],
         }
@@ -174,6 +180,7 @@ class PackagesResourceGetTests(DatabaseTestCase):
                     "project": "requests",
                     "ecosystem": "pypi",
                     "version": "1",
+                    "stable_version": None,
                 },
                 {
                     "distribution": "Debian",
@@ -181,6 +188,7 @@ class PackagesResourceGetTests(DatabaseTestCase):
                     "project": "requests",
                     "ecosystem": "pypi",
                     "version": "1",
+                    "stable_version": None,
                 },
             ],
         }
@@ -222,6 +230,7 @@ class PackagesResourceGetTests(DatabaseTestCase):
                     "project": "requests",
                     "ecosystem": "pypi",
                     "version": "1",
+                    "stable_version": None,
                 },
                 {
                     "distribution": "Debian",
@@ -229,6 +238,7 @@ class PackagesResourceGetTests(DatabaseTestCase):
                     "project": "requests",
                     "ecosystem": "pypi",
                     "version": "1",
+                    "stable_version": None,
                 },
             ],
         }
@@ -277,6 +287,7 @@ class PackagesResourceGetTests(DatabaseTestCase):
                     "project": "requests",
                     "ecosystem": "pypi",
                     "version": "1",
+                    "stable_version": None,
                 }
             ],
         }
@@ -314,6 +325,7 @@ class PackagesResourceGetTests(DatabaseTestCase):
                     "project": "requests",
                     "ecosystem": "pypi",
                     "version": "1",
+                    "stable_version": None,
                 }
             ],
         }
@@ -354,6 +366,7 @@ class PackagesResourceGetTests(DatabaseTestCase):
                     "project": "requests",
                     "ecosystem": "pypi",
                     "version": "1",
+                    "stable_version": None,
                 }
             ],
         }
@@ -368,6 +381,7 @@ class PackagesResourceGetTests(DatabaseTestCase):
                     "project": "requests",
                     "ecosystem": "pypi",
                     "version": "1",
+                    "stable_version": None,
                 }
             ],
         }

--- a/news/1033.api
+++ b/news/1033.api
@@ -1,0 +1,1 @@
+add stable_version as output in PackagesResource


### PR DESCRIPTION
We at Gentoo plan to use this great infra to find which of our packages are outdated. One very small gripe with current existing APIs that I can't get the latest stable versions across all projects under Gentoo distribution, since it returns only latest version, which include pre-releases.

As suggested in this issue (and I also had similar idea myself before I found this issue), I've added an extra small property which holds the latest stable version. If there are none (for example all versions are pre-release), it will return None, which would be converted to `null` in JSON. I think this is the best way to represent the current state to the consumers.

This is my first contribution to this project, so if I mistook something I'll be happy to fix and improve. Also, the listed example update might not be the best, since for that case latest version is also stable, so if requested I can select better example (I think PyPI/moto is good one).

Resolves: https://github.com/fedora-infra/anitya/issues/1033