### PR TITLE
Fix the arbitrary URL jumping of /login.

### DIFF
--- a/anitya/tests/test_flask.py
+++ b/anitya/tests/test_flask.py
@@ -488,6 +488,15 @@ class FlaskTest(DatabaseTestCase):
             self.assertEqual(output.status_code, 302)
             self.assertEqual(output.headers["Location"], "/project/1")
 
+    def test_login_arbitrary_redirection(self):
+        """Test redirection when session contains outside next_url field."""
+        self.app.get("/login?next=http://example.com")
+
+        with login_user(self.flask_app, self.user):
+            output = self.app.get("/")
+            self.assertEqual(output.status_code, 302)
+            self.assertEqual(output.headers["Location"], "/")
+
     def test_about(self):
         """Assert the legacy about endpoint redirects to documentation"""
         output = self.app.get("/about")

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -49,7 +49,11 @@ def about():
 @ui_blueprint.route("/login/", methods=("GET", "POST"))
 @ui_blueprint.route("/login", methods=("GET", "POST"))
 def login():
-    flask.session["next_url"] = flask.request.args.get("next", "/")
+    next_url = flask.request.args.get("next", "/")
+    if not next_url.startswith("/"):
+        next_url = "/"
+
+    flask.session["next_url"] = next_url
     return flask.render_template("login.html")
 
 


### PR DESCRIPTION
Hi, the /login handler has a vulnerability. 

The `next' parameter does not check the range of the target URL for the jump, so it can jump to any URL, for example

/login/?next=https://fedoraproject.org

I fixed it.