### PR TITLE
Update dev env to Fedora 38

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -39,6 +39,6 @@ RUN pip install dist/*.whl
 
 # Hotfix for social_auth-sqlalchemy
 # Should be removed when we switch to something else
-RUN sed -i 's/base64.encodestring/base64.encodebytes/g' /usr/local/lib/python3.10/site-packages/social_sqlalchemy/storage.py
+RUN sed -i 's/base64.encodestring/base64.encodebytes/g' /usr/local/lib/python3.11/site-packages/social_sqlalchemy/storage.py
 
 CMD ["sh","-c", "poetry build && pip install dist/*.whl && eval '$START_COMMAND'"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
- config.vm.box = "fedora/36-cloud-base"
+ config.vm.box = "fedora/38-cloud-base"
 
  # Forward traffic on the host to the development server on the guest
  config.vm.network "forwarded_port", guest: 5000, host: 5000

--- a/ansible/roles/anitya-dev/tasks/db.yml
+++ b/ansible/roles/anitya-dev/tasks/db.yml
@@ -67,7 +67,7 @@
 
 - name: Apply database migrations
   become_user: "{{ ansible_env.SUDO_USER }}"
-  command: alembic-3 upgrade head
+  command: python3 -m alembic.config upgrade head
   args:
       chdir: /home/vagrant/
   when: import_production_database

--- a/ansible/roles/anitya-dev/tasks/main.yml
+++ b/ansible/roles/anitya-dev/tasks/main.yml
@@ -47,7 +47,6 @@
            python3-dateutil,
            python3-defusedxml,
            python3-flask-login,
-           python3-flask-restful,
            python3-flask-wtf,
            python3-jinja2,
            python3-ordered-set,
@@ -119,7 +118,7 @@
 # Could be removed when we move away from social_auth
 - name: Hotfix for social_auth
   replace:
-    path: /usr/local/lib/python3.10/site-packages/social_sqlalchemy/storage.py
+    path: /usr/local/lib/python3.11/site-packages/social_sqlalchemy/storage.py
     regexp: 'base64\.encodestring'
     replace: 'base64.encodebytes'
 

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: Containerfile.dev
       args:
-        FEDORA_VERSION: 36
+        FEDORA_VERSION: 38
     container_name: "anitya-web"
     ports:
       - "127.0.0.1:5000:5000"
@@ -30,7 +30,7 @@ services:
       context: .
       dockerfile: Containerfile.dev
       args:
-        FEDORA_VERSION: 36
+        FEDORA_VERSION: 38
     container_name: "anitya-librariesio-consumer"
     volumes:
       - ./anitya/:/app/anitya:z


### PR DESCRIPTION
Update container and vagrant development environment to Fedora 38.

Closes #1565