### PR TITLE
Prevent error when python versioning parsing non version string

### DIFF
--- a/anitya/lib/versions/python.py
+++ b/anitya/lib/versions/python.py
@@ -68,7 +68,11 @@ class PythonVersion(base.Version):
         """
         Return string representation of the version object
         """
-        return str(self.version_object())
+        try:
+            return str(self.version_object())
+        except base.InvalidVersion:
+            # When the version can't be validated by packaging.version module just return the string
+            return super().parse()
 
     def prerelease(self):
         """

--- a/anitya/tests/lib/versions/test_python.py
+++ b/anitya/tests/lib/versions/test_python.py
@@ -39,6 +39,11 @@ class PythonVersionTests(unittest.TestCase):
         """
         self.assertEqual("Python (PEP 440)", python.PythonVersion.name)
 
+    def test_non_version_string(self):
+        """Assert that version string which is not version will be handled correctly."""
+        version = python.PythonVersion(version="unstable")
+        self.assertEqual(version.parse(), "unstable")
+
     def test_prerelease_false(self):
         """Assert prerelease is defined and returns False with non-prerelease versions."""
         version = python.PythonVersion(version="1.0.0")

--- a/news/1590.bug
+++ b/news/1590.bug
@@ -1,0 +1,1 @@
+Fix 500 when accesing project with PYTHON versioning scheme when the version is not a correct version


### PR DESCRIPTION
This caused 500 when opening project page with version that is not a version string.

Fixes #1590