### PR TITLE
Update minimum python version to 3.8.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ check_service = "anitya.check_service:main"
 sar = "anitya.sar:main"
 
 [tool.poetry.dependencies]
-python = "^3.8.1"
+python = "^3.8.10"
 alembic = "^1.8.1"
 anitya-schema = "^2.0.1"
 arrow = "^1.2.3"


### PR DESCRIPTION
diff-cover 8.0.0+ has minimum python requirements 3.8.10, let's update it then.