### PR TITLE
Support odd-numbered pre-release version filtering

### DIFF
--- a/anitya/lib/versions/base.py
+++ b/anitya/lib/versions/base.py
@@ -122,13 +122,24 @@ class Version(object):
 
         return version
 
-    def prerelease(self):
+    def prerelease(self) -> bool:
         """
         Check if a version is a pre-release version.
 
         This basic version implementation does not have a concept of
         pre-releases.
         """
+
+        if not self.version:
+            return False
+
+        for pre_release_filter in self.pre_release_filters:
+            if not pre_release_filter:
+                return False
+
+            if pre_release_filter in self.version:
+                return True
+
         return False
 
     def postrelease(self):

--- a/anitya/lib/versions/calver.py
+++ b/anitya/lib/versions/calver.py
@@ -274,15 +274,7 @@ class CalendarVersion(Version):
         if version_dict["modifier"]:
             return True
 
-        for pre_release_filter in self.pre_release_filters:
-            if (
-                pre_release_filter
-                and self.version
-                and pre_release_filter in self.version
-            ):
-                return True
-
-        return False
+        return super().prerelease()
 
     def __eq__(self, other) -> bool:
         """

--- a/anitya/lib/versions/python.py
+++ b/anitya/lib/versions/python.py
@@ -107,18 +107,17 @@ class PythonVersion(base.Version):
         else:
             return super().parse()
 
-    def prerelease(self):
+    def prerelease(self) -> bool:
         """
         Check this is a pre-release version.
         """
         if not self.version_object:
             return False
 
-        for pre_release_filter in self.pre_release_filters:
-            if pre_release_filter and pre_release_filter in self.version:
-                return True
+        if self.version_object.is_prerelease:
+            return True
 
-        return self.version_object.is_prerelease
+        return super().prerelease()
 
     def postrelease(self):
         """

--- a/anitya/lib/versions/rpm.py
+++ b/anitya/lib/versions/rpm.py
@@ -136,7 +136,7 @@ class RpmVersion(Version):
 
         return (match.group(1), match.group(3), match.group(4))
 
-    def prerelease(self):
+    def prerelease(self) -> bool:
         """
         Check if a version is a pre-release version.
 
@@ -146,11 +146,7 @@ class RpmVersion(Version):
         if self.split_rc(self.parse())[1]:
             return True
 
-        for pre_release_filter in self.pre_release_filters:
-            if pre_release_filter and pre_release_filter in self.version:
-                return True
-
-        return False
+        return super().prerelease()
 
     def __eq__(self, other):
         """

--- a/anitya/lib/versions/semver.py
+++ b/anitya/lib/versions/semver.py
@@ -42,7 +42,7 @@ class SemanticVersion(Version):
 
     name = "Semantic"
 
-    def prerelease(self):
+    def prerelease(self) -> bool:
         """
         Check if a version is a pre-release version.
 
@@ -64,11 +64,7 @@ class SemanticVersion(Version):
         if version_info.prerelease:
             return True
 
-        for pre_release_filter in self.pre_release_filters:
-            if pre_release_filter and pre_release_filter in self.version:
-                return True
-
-        return False
+        return super().prerelease()
 
     def __eq__(self, other):
         """

--- a/anitya/tests/lib/versions/test_base.py
+++ b/anitya/tests/lib/versions/test_base.py
@@ -99,9 +99,64 @@ class VersionTests(unittest.TestCase):
         version = base.Version(version="release_db-1.2.3", prefix="release_db-; ")
         self.assertEqual("1.2.3", version.parse())
 
-    def test_prerelease(self):
+    def test_prerelease_default(self):
         """Assert prerelease is defined and returns False"""
         version = base.Version(version="v1.0.0")
+        self.assertFalse(version.prerelease())
+
+    def test_prerelease_str_single(self):
+        """Assert pre-releases will be valid if filter is applied."""
+        version = base.Version(version="1.0.0", pre_release_filter="1.")
+        self.assertTrue(version.prerelease())
+
+    def test_prerelease_str_multiple(self):
+        """Assert pre-releases will be valid if multiple filters is applied."""
+        version = base.Version(version="v1.0.0", pre_release_filter="a;v")
+        self.assertTrue(version.prerelease())
+
+    def test_prerelease_odds_default_even(self):
+        """Assert even pre-releases are not flagged with odds-check."""
+        version = base.Version(version="v1.2.0", pre_release_filter="!odds")
+        self.assertFalse(version.prerelease())
+
+    def test_prerelease_odds_default_odd(self):
+        """Assert odd pre-releases are flagged with odds-check."""
+        version = base.Version(version="v1.3.0", pre_release_filter="!odds")
+        self.assertTrue(version.prerelease())
+
+    def test_prerelease_odds_micro_even(self):
+        """Assert even-micro pre-releases are not flagged with odds-check."""
+        version = base.Version(version="2.0.6", pre_release_filter="!odds:2")
+        self.assertFalse(version.prerelease())
+
+    def test_prerelease_odds_micro_odd(self):
+        """Assert odd-micro pre-releases are flagged with odds-check."""
+        version = base.Version(version="2.0.7", pre_release_filter="!odds:2")
+        self.assertTrue(version.prerelease())
+
+    def test_prerelease_odds_invalid_index(self):
+        """Assert prerelease ignores an odds-check with an invalid index."""
+        version = base.Version(version="v1.3.0", pre_release_filter="!odds:5")
+        self.assertFalse(version.prerelease())
+
+    def test_prerelease_odds_unsupported_version(self):
+        """Assert prerelease ignores an odds-check with an unsupported version."""
+        version = base.Version(version="latest", pre_release_filter="!odds")
+        self.assertFalse(version.prerelease())
+
+    def test_prerelease_odds_multiple(self):
+        """Assert pre-releases will be valid if multiple filters is applied."""
+        version = base.Version(version="v1.3.0", pre_release_filter="alpha;!odds")
+        self.assertTrue(version.prerelease())
+
+    def test_prerelease_misc_invalid_filter(self):
+        """Assert prerelease ignores invalid filters."""
+        version = base.Version(version="1.0.0", pre_release_filter=";")
+        self.assertFalse(version.prerelease())
+
+    def test_prerelease_misc_invalid_version(self):
+        """Assert prerelease ignores invalid version."""
+        version = base.Version(version=None)
         self.assertFalse(version.prerelease())
 
     def test_postrelease(self):

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -326,15 +326,27 @@ More concrete examples:
 Pre-release filter
 ------------------
 
-Sometimes the recognition of stable and unstable versions by :ref:`version-scheme` isn't
-working for the project and in this field you can specify strings that will be considered
-as unstable release.
+Anitya will attempt recognition of stable and unstable versions for projects
+using :ref:`version schemes <version-scheme>`. Sometimes recognition may not
+work for a project and in this field a user can specify strings that will be
+considered as unstable release.
 
 For example, if the project's version are: ``1.2alpha``, you can set the
 pre-release filter to ``alpha`` to tell Anitya to treat this release as unstable.
 
 You can specify multiple filters by separating them by ``;``. For example
 ``alpha;beta`` will mark versions with ``alpha`` and ``beta`` as unstable.
+
+For projects using odd-numbered versions for development releases, the filter
+pattern ``!odds[:n]`` can be used to help identify development releases as
+pre-releases. For projects which use an odd minor version to identify
+development releases, a filter ``!odds`` can be used (e.g. versions ``1.0`` and
+``1.2`` is considered a stable version, where ``1.1`` is considered a
+pre-release version). For projects which use a different field as a marker for
+old versions, an offset value (``n``) can be provided. For example, the filter
+``!odds:2`` can be used to configure an odd micro version to identify
+development releases (e.g. versions ``1.0.4`` and ``1.0.6`` is considered a
+stable version, where ``1.0.5`` is considered a pre-release version).
 
 .. note::
    This filter is applied after recognition of unstable versions by :ref:`version-scheme`.


### PR DESCRIPTION
This commit introduces a filter pattern `!odds[:n]`, which can be used to help identify pre-release versions for packages using odd-numbered versions for development releases. This convenience filter can be used over having to add explicit exceptions for each odd version entry for projects using odd-numbered development releases.

For example, if a project configures a pre-release filter using the value `!odds`, any odd-numbered minor version for a project will be flagged as a pre-release. For example, versions `1.0` and `1.2` will be considered stable versions, as where `1.1` is considered a pre-release version.