### PR TITLE
Add version pattern to the documentation

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -296,6 +296,18 @@ Anitya provides several different versions schemes.
     recent scheme and the rest will be moved to bottom unsorted.
 
 
+
+Version Pattern
+---------------
+
+The version pattern is used to extract and match version numbers from project releases. When defining a version pattern, you can use regular expressions to specify the format of the version numbers.
+
+In many cases, projects follow a format like `X.Y.Z` where `X`, `Y`, and `Z` are integers representing major, minor, and patch versions respectively. To match this format, you can use the following regular expression:
+
+v?(\d+\.\d+\.\d+)
+
+
+
 Version Prefix
 --------------
 


### PR DESCRIPTION
### Description
This pull request adds the version pattern to the documentation. The version pattern is used to extract and match version numbers from project releases. It helps users understand how versioning is structured and how to interpret project version numbers.

### Changes Made
- Added the version pattern to the documentation.
- Included the regular expression `v?(\d+\.\d+\.\d+)` to match version numbers like `0.12.1`, `1.0.0`, etc., following the calendar versioning format.

### Purpose
- Provide clarity on the versioning scheme used in the project, specifically calendar versioning (CalVer).
- Help users easily understand and work with version numbers when interacting with the project.

### Additional Notes
This version pattern is designed for projects following the calendar versioning scheme (CalVer). If there are any changes or updates needed to the pattern, please let me know.

This PR closes issue #1604

