### PR TITLE
Fix the authentication issue

### DIFF
--- a/anitya/db/models.py
+++ b/anitya/db/models.py
@@ -915,6 +915,8 @@ class GUID(TypeDecorator):
         """
         if value is None:
             return value
+        if isinstance(value, uuid.UUID):
+            return value
         else:
             return uuid.UUID(value)
 

--- a/anitya/tests/db/test_models.py
+++ b/anitya/tests/db/test_models.py
@@ -1041,6 +1041,16 @@ class GuidTests(unittest.TestCase):
         self.assertTrue(isinstance(result, UUID))
         self.assertEqual(uuid, result)
 
+    def test_process_result_uuid(self):
+        """Assert when the result value is a UUID it is returned."""
+        guid = models.GUID()
+        uuid = uuid4()
+
+        result = guid.process_result_value(uuid, sqlite.dialect())
+
+        self.assertTrue(isinstance(result, UUID))
+        self.assertEqual(uuid, result)
+
 
 class UserTests(DatabaseTestCase):
     """UserTests class"""

--- a/news/1727.bug
+++ b/news/1727.bug
@@ -1,0 +1,1 @@
+Error when uuid object is returned from Fedora Account System


### PR DESCRIPTION
Anitya is currently expects either `None` or `hex` as `UUID` values returned during authentication. This is solving the case when `UUID` object is returned directly.

Fixes #1727