### PR TITLE
Fix the container dev environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ endef
 
 up:
 	$(call compose-tool) up -d
-	sleep 3
+# It takes some time before the postgres container is up, we need to wait before calling
+# the next step
+	sleep 10
 	$(MAKE) init-db
 	@echo "Empty database initialized. Run dump-restore to fill it by production dump."
 restart:
@@ -39,5 +41,5 @@ logs:
 clean: halt
 	$(call container-tool) rmi "localhost/anitya-base:latest" "docker.io/library/postgres:13.4" "docker.io/library/rabbitmq:3.8.16-management-alpine"
 
-.PHONY: up restart halt bash-web bash-consumer \
+.PHONY: up restart halt bash-web \
 	init-db dump-restore logs clean

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -29,7 +29,6 @@ services:
     container_name: "rabbitmq"
     restart: unless-stopped
     ports:
-      - "5672:5672"
       - "15672:15672"
     healthcheck:
       test: [ "CMD", "nc", "-z", "localhost", "5672" ]
@@ -44,10 +43,8 @@ services:
     image: docker.io/library/postgres:13.4
     container_name: "postgres"
     user: postgres
-    ports:
-      - "5432:5432"
     volumes:
-      - .container/dump:/dump
+      - .container/dump:/dump:z
     healthcheck:
       test: ["CMD-SHELL", "pg_isready"]
       interval: 3s


### PR DESCRIPTION
This will fix the issue with containerized environment.

* Remove exposed ports as those are not needed to be exposed to host
* Increase the time to wait for postgres DB to start
* Add SELinux context to dump folder