### PR TITLE
social_sqlalchemy

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -278,6 +278,23 @@ Create the database, by default it will be a sqlite database located at
 
     $ poetry run python createdb.py
 
+Configure social_sqlalchemy for Anitya if needed. This step is optional and depends on your use case: ::
+
+    #Example configuration for social_sqlalchemy in a Anitya
+    #in anitya/config.py
+    from flask import Flask
+    from social_flask_sqlalchemy.models import init_social
+
+    app = Flask(__name__)
+
+    #Configure SQLAlchemy database
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///your_database.db'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+    #Initialize social_sqlalchemy 
+    init_social(app, app.config['SQLALCHEMY_ENGINE'])
+
+
 You can start the development web server included with Flask with::
 
     $ FLASK_APP=anitya.wsgi poetry run flask run

--- a/news/1723.other
+++ b/news/1723.other
@@ -1,0 +1,1 @@
+- Added instructions for configuring `social_sqlalchemy` in Anitya to the contributing guidelines.


### PR DESCRIPTION
Description:
This pull request adds optional instructions for configuring social_sqlalchemy, a package for SQLAlchemy storage support for Python Social Auth, in Anitya . It provides a code example demonstrating how to set up social_sqlalchemy in a Anitya , including configuring the SQLAlchemy database and initializing social_sqlalchemy. Additionally, it includes a note on starting the development web server with Flask.

Purpose:
The purpose of this pull request is to enhance the contributing guidelines by providing guidance on integrating social_sqlalchemy with Anitya for OAuth and OAuth2 authentication. This addition aims to assist contributors who may want to use social_sqlalchemy in Anitya project, thereby improving the overall development experience for Anitya contributors.

Changes Made:
Added instructions for configuring social_sqlalchemy in Flask applications to the contributing.rst file.
Included a code example demonstrating the setup process for social_sqlalchemy.
Updated the Python Virtualenv section of the contributing.rst file to include these instructions.
Testing:
These instructions were tested locally by following the provided steps to configure social_sqlalchemy in a Anitya application within a Python virtual environment. The Flask development server was started successfully, indicating that the setup process was correct and functional.

Related Issue:
https://github.com/fedora-infra/anitya/issues/1723