### PR TITLE
Adding version pattern to user-guide.rst

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -296,6 +296,32 @@ Anitya provides several different versions schemes.
     recent scheme and the rest will be moved to bottom unsorted.
 
 
+Version Pattern
+===============
+
+The version pattern is used to define how the calendar version should be
+parsed and how they will be sorted. It allows for specifying the format 
+for calendar versioning scheme using following patterns.
+
+Patterns -
+
+- ``YYYY``: Full year (e.g., 2006, 2016, 2106).
+- ``YY``: Short year (e.g., 6, 16, 106).
+- ``0Y``: Zero-padded year (e.g., 06, 16, 106).
+- ``MM``: Short month (e.g., 1, 2, ..., 11, 12).
+- ``0M``: Zero-padded month (e.g., 01, 02, ..., 11, 12).
+- ``WW``: Short week (since the start of the year) (e.g., 1, 2, 33, 52).
+- ``0W``: Zero-padded week (e.g., 01, 02, 33, 52).
+- ``DD``: Short day (e.g., 1, 2, ..., 30, 31).
+- ``0D``: Zero-padded day (e.g., 01, 02, ..., 30, 31).
+
+.. note::
+    Traditional, incremented version numbers are 0-based, whereas date
+    segments are 1-based, and the short and zero-padded years are relative
+    to the year 2000. Usage of weeks is usually mutually exclusive
+    with months/days.
+
+
 Version Prefix
 --------------
 


### PR DESCRIPTION
## Pull Request: Add Version Pattern Documentation to User Guide

### Issue

Fixes #1604 

### Description

This pull request adds documentation for the version pattern field in the user guide. The version pattern field is essential for extracting and matching version numbers from project releases, and it allows users to specify the format of version numbers using regular expressions. This documentation clarifies the usage of various pattern tokens such as `YYYY`, `YY`, `MM`, `WW`, `DD`, etc., along with their examples and notes on usage.

### Changes Made

- Added a new section titled "Version Pattern" to the user guide (`user-guide.rst`).
- Provided detailed explanations and examples for each pattern token (`YYYY`, `YY`, `MM`, `WW`, `DD`, etc.).
- Included notes on traditional version numbering, the relative nature of short and zero-padded years, and the mutual exclusivity of weeks with months/days.

### Testing Done

- Reviewed the changes locally to ensure accuracy and clarity.
- Checked for formatting and consistency with existing documentation.

### Additional Notes

- This documentation enhancement aims to improve usability and clarity for users configuring the version pattern field.
- Any feedback or suggestions for improvement are welcome.

---
*Please review and merge this pull request at your earliest convenience. Thank you!*
