### PR TITLE
Fix the RTD build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,10 +11,16 @@ build:
   tools:
     python: "3.10"
   jobs:
-    post_install:
+    post_create_environment:
+      # Install poetry
+      # https://python-poetry.org/docs/#installing-manually
       - pip install poetry
-      - poetry config virtualenvs.create false
-      - poetry install
+    post_install:
+      # Install dependencies with 'docs' dependency group
+      # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
+      # VIRTUAL_ENV needs to be set manually for now.
+      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
 
 # Sphinx configuration
 sphinx:


### PR DESCRIPTION
The build is currently failing, but this should fix that according to https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-poetry