### PR TITLE
Remove the docs dependency group from RTD build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,11 +16,9 @@ build:
       # https://python-poetry.org/docs/#installing-manually
       - pip install poetry
     post_install:
-      # Install dependencies with 'docs' dependency group
-      # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
       # VIRTUAL_ENV needs to be set manually for now.
       # See https://github.com/readthedocs/readthedocs.org/pull/11152/
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install
 
 # Sphinx configuration
 sphinx:


### PR DESCRIPTION
We don't have that, just install the dependencies and project itself to virtual env.