### PR TITLE
Revert "Remove while loop from check_service"

### DIFF
--- a/anitya/tests/test_check_service.py
+++ b/anitya/tests/test_check_service.py
@@ -24,7 +24,6 @@ Anitya tests for check service.
 """
 
 import unittest
-from concurrent.futures import Future
 from datetime import timedelta
 from unittest import mock
 
@@ -383,8 +382,8 @@ class CheckerTests(DatabaseTestCase):
         self.assertEqual(len(run_objects), 1)
         self.assertEqual(run_objects[0].total_count, 2)
 
-    @mock.patch("anitya.check_service.wait", return_value=([], [Future(), Future()]))
-    def test_run_timeout(self, mock_wait):
+    @mock.patch("anitya.check_service.as_completed", side_effect=TimeoutError())
+    def test_run_timeout(self, mock_as_completed):
         """
         Assert that TimeoutError is thrown when TIMEOUT is reached.
         """

--- a/news/1806.dev
+++ b/news/1806.dev
@@ -1,1 +1,0 @@
-Rewrite parallelization part of check service


### PR DESCRIPTION
This reverts commit 46d2863d07dbd395d59f8febc65da55cc6b54d84.

I was able to find the issue that caused the threads to be stuck in the production. It was caused by some deadlock in the database, operations waiting on each other. I'm not sure what caused it, but after removing the locks the processing is working again and there wasn't any thread stuck till then.

Also this change is causing errors to happen when tested on staging. From the first look it seems to be caused by simultaneous access to the database for insert operation, but as the original code is working and the issue wasn't caused by it I'm reverting this commit.