### PR TITLE
Fix: Internal server error when adding packages

### DIFF
--- a/anitya/api_v2.py
+++ b/anitya/api_v2.py
@@ -243,13 +243,12 @@ class PackagesResource(MethodView):
             args = parser.parse(user_args, request, location="form")
         else:
             args = parser.parse(user_args, request, location="json")
-        try:
-            project = models.Project.query.filter(
-                func.lower(models.Project.name) == func.lower(args["project_name"]),
-                func.lower(models.Project.ecosystem_name)
-                == func.lower(args["project_ecosystem"]),
-            ).one()
-        except NoResultFound:
+        project = models.Project.query.filter(
+            func.lower(models.Project.name) == func.lower(args["project_name"]),
+            func.lower(models.Project.ecosystem_name)
+            == func.lower(args["project_ecosystem"]),
+        ).first()
+        if not project:
             return (
                 {
                     "error": f'Project "{args["project_name"]}" in ecosystem '

--- a/news/1911.bug
+++ b/news/1911.bug
@@ -1,0 +1,1 @@
+Fix: Internal server error when adding packages


### PR DESCRIPTION
When adding packages sometimes the query finds more than one entry. Although there are no duplicates in the database it happens sometimes. To prevent this let's pick the first entry from the returned results.

This is not the final fix, but it should be enough to resolve the issue with 500 for now.

Fixes #1911