### PR TITLE
Add check for version_url to API

### DIFF
--- a/anitya/api_v2.py
+++ b/anitya/api_v2.py
@@ -18,7 +18,7 @@ from webargs.flaskparser import FlaskParser
 
 from anitya import authentication
 from anitya.db import Session, models
-from anitya.lib import utilities
+from anitya.lib import plugins, utilities
 from anitya.lib.exceptions import AnityaException, ProjectExists
 
 _log = logging.getLogger(__name__)
@@ -493,6 +493,15 @@ class ProjectsResource(MethodView):
             args = parser.parse(user_args, request, location="form")
         else:
             args = parser.parse(user_args, request, location="json")
+
+        if not args["version_url"]:
+            backend = plugins.get_plugin(args["backend"])
+            if backend.required_version_url:
+                response = (
+                    jsonify("Chosen backend requires version_url"),
+                    400,
+                )
+                return response
 
         try:
             project = utilities.create_project(

--- a/anitya/lib/backends/__init__.py
+++ b/anitya/lib/backends/__init__.py
@@ -78,6 +78,9 @@ class BaseBackend(object):
             is used.
         check_interval (`datetime.timedelta`): Interval which is used for periodic
             checking for new versions. This could be overriden by backend plugin.
+        required_version_url (bool): This flag will let us know if the version URL
+            is required field on project backend. Default is False as most of the
+            backends don't require it.
     """
 
     name: str
@@ -86,6 +89,7 @@ class BaseBackend(object):
     more_info: str
     default_version_scheme = GLOBAL_DEFAULT
     check_interval = timedelta(hours=1)
+    required_version_url: bool = False
 
     @classmethod
     def expand_subdirs(cls, url, last_change=None, glob_char="*"):

--- a/anitya/lib/backends/custom.py
+++ b/anitya/lib/backends/custom.py
@@ -31,6 +31,7 @@ class CustomBackend(BaseBackend):
         "user-guide.html#regular-expressions</a>"
     )
     default_regex = REGEX % {"name": "{project name}"}
+    required_version_url = True
 
     @classmethod
     def get_version_url(cls, project):

--- a/anitya/lib/backends/folder.py
+++ b/anitya/lib/backends/folder.py
@@ -28,6 +28,7 @@ class FolderBackend(BaseBackend):
         "https://ftp.gnu.org/pub/gnu/gnash/",
         "https://subsurface-divelog.org/downloads/",
     ]
+    required_version_url = True
 
     @classmethod
     def get_version_url(cls, project):

--- a/anitya/tests/test_flask_api_v2.py
+++ b/anitya/tests/test_flask_api_v2.py
@@ -1211,6 +1211,26 @@ class ProjectsResourcePostTests(DatabaseTestCase):
         )
         self.assertEqual("requests", data["requested_project"]["name"])
 
+    def test_required_version_url_for_backend(self):
+        """
+        Assert that backend with required version url will return 400
+        if version url is missing.
+        """
+        request_data = {
+            "backend": "custom",
+            "homepage": "http://python-requests.org",
+            "name": "requests",
+        }
+
+        output = self.app.post(
+            "/api/v2/projects/", headers=self.auth, data=request_data
+        )
+        self.assertEqual(output.status_code, 400)
+
+        # Error details should report conflicting fields.
+        data = _read_json(output)
+        self.assertIn("Chosen backend requires version_url", data)
+
     def test_valid_request(self):
         """Test valid request"""
         request_data = {

--- a/news/1921.api
+++ b/news/1921.api
@@ -1,0 +1,1 @@
+Fix: Should not allow projects with no way to check versions


### PR DESCRIPTION
The API doesn't check if the version_url is filled when the backend requires it. The project created this way will be removed after 1000 failed checks, but we still should prevent this by checking if the version_url is filled.

So this PR is adding new attribute to backends, which is checked when creating new project using API.

Fixes #1921