### PR TITLE
Make it more obvious to use the Gitea backend for Forgejo/Codeberg

### DIFF
--- a/anitya/lib/backends/gitea.py
+++ b/anitya/lib/backends/gitea.py
@@ -27,7 +27,7 @@ class GiteaBackend(BaseBackend):
     with gitea api.
     """
 
-    name = "Gitea"
+    name = "Gitea/Forgejo"
     examples = [
         "https://codeberg.org/freedroid/freedroid-src.git",
         "https://codeberg.org/forgejo/forgejo",

--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -252,8 +252,8 @@
       $("#version_url").prop('title', "This field should be filled when " +
       "homepage doesn't point to GitLab URL.");
     };
-    if (str == 'Gitea'){
-      $("label[for='version_url']").text('Gitea/Forgejo project url');
+    if (str == 'Gitea/Forgejo'){
+      $("label[for='version_url']").text('Gitea/Forgejo/Codeberg project url');
       $('#version_url_row').show();
       $("#version_url").prop('title', "This field should be filled when " +
       "homepage doesn't point to Gitea or Forgejo URL.");

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -171,7 +171,7 @@ The backends available are:
   Gitea API.
 
   You need to provide **Gitea/Forgejo project url** which needs to point to project root on
-  either Gitea server or Forgejo server.
+  either Gitea server or Forgejo server (e.g., `Codeberg <https://codeberg.org/>`_).
 
 * **GNOME** for projects hosted on
   `download.gnome.org <https://download.gnome.org/sources/>`_


### PR DESCRIPTION
I tried to follow the instructions at https://anitya.readthedocs.io/en/latest/contributing.html#docker-podman but couldn't get it working, so these changes are untested.