### PR TITLE
Remove GitHub ratelimit threshold

### DIFF
--- a/anitya/lib/backends/github.py
+++ b/anitya/lib/backends/github.py
@@ -18,12 +18,6 @@ from anitya.lib.exceptions import AnityaPluginException, RateLimitException
 
 API_URL = "https://api.github.com/graphql"
 
-"""
-Rate limit threshold (percent)
-10 percent of limit is left for users
-"""
-RATE_LIMIT_THRESHOLD = 0.1
-
 _log = logging.getLogger(__name__)
 
 """
@@ -210,7 +204,6 @@ def parse_json(json, project):
     # We need to check limit first,
     # because exceeding the limit will also return error
     try:
-        limit = json["data"]["rateLimit"]["limit"]
         remaining = json["data"]["rateLimit"]["remaining"]
         reset_time = json["data"]["rateLimit"]["resetAt"]
         _log.debug(
@@ -219,7 +212,7 @@ def parse_json(json, project):
             reset_time,
         )
 
-        if (remaining / limit) <= RATE_LIMIT_THRESHOLD:
+        if remaining <= 0:
             raise RateLimitException(reset_time)
     except KeyError:
         _log.info("Github API ratelimit key is missing. Checking for errors.")

--- a/anitya/tests/lib/backends/test_github.py
+++ b/anitya/tests/lib/backends/test_github.py
@@ -627,31 +627,6 @@ class JsonTests(unittest.TestCase):
             backend.parse_json(json, self.project)
         self.assertEqual(backend.reset_time, "2008-09-03T20:56:35.450686")
 
-    def test_parse_json_threshold_reached(self):
-        """
-        Assert that exception is thrown when
-        rate limit threshold is reached.
-        """
-        project = models.Project(
-            name="foobar",
-            homepage="https://foobar.com",
-            version_url="foo/bar",
-            backend=BACKEND,
-        )
-        json = {
-            "data": {
-                "repository": {"refs": {"totalCount": 0}},
-                "rateLimit": {
-                    "limit": 5000,
-                    "remaining": 500,
-                    "resetAt": "2008-09-03T20:56:35.450686",
-                },
-            }
-        }
-        with self.assertRaises(RateLimitException):
-            backend.parse_json(json, project)
-        self.assertEqual(backend.reset_time, "2008-09-03T20:56:35.450686")
-
     def test_parse_json_tag_missing(self):
         """Test parsing a JSON skips releases where tag is missing."""
         project = models.Project(

--- a/news/PR1968.bug
+++ b/news/PR1968.bug
@@ -1,0 +1,1 @@
+Remove ratelimit threshold for GitHub


### PR DESCRIPTION
Original idea behind the threshold was to keep 10% of ratelimit for manual checks by user, but this didn't work as expected as even the manual checks were hitting this threshold. It would be better to rather use the whole ratelimit.