### PR TITLE
Check the blacklisted packages on reset_time

### DIFF
--- a/news/PR1969.bug
+++ b/news/PR1969.bug
@@ -1,0 +1,1 @@
+Check the blacklisted packages on reset_time


### PR DESCRIPTION
The blacklisted packages are not checked when the reset_time is reached, but on the next check. This could take a lot of time, let's check them once the we reach the time.