### PR TITLE
Check GitHub ratelimit correctly

### DIFF
--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_gargoyle
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_gargoyle
@@ -49,7 +49,7 @@ interactions:
       x-oauth-scopes: ['repo:status']
       x-ratelimit-limit: ['5000']
       x-ratelimit-remaining: ['5000']
-      x-ratelimit-reset: ['1539938803']
+      x-ratelimit-reset: ['2147483647']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}
 version: 1

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_version_invalid_unknown_project
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_version_invalid_unknown_project
@@ -72,7 +72,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4999'
       X-RateLimit-Reset:
-      - '1576605150'
+      - '2147483647'
       X-XSS-Protection:
       - 1; mode=block
       content-length:

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_version_valid_with_version_url
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_version_valid_with_version_url
@@ -71,7 +71,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4996'
       X-RateLimit-Reset:
-      - '1576605295'
+      - '2147483647'
       X-XSS-Protection:
       - 1; mode=block
       content-length:

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_version_valid_without_version_url
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_version_valid_without_version_url
@@ -71,7 +71,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4994'
       X-RateLimit-Reset:
-      - '1576605418'
+      - '2147483647'
       X-XSS-Protection:
       - 1; mode=block
       content-length:

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_versions_filter
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_versions_filter
@@ -89,7 +89,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4999'
       X-RateLimit-Reset:
-      - '1615217132'
+      - '2147483647'
       X-RateLimit-Used:
       - '1'
       X-XSS-Protection:

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_versions_invalid_unknown_project
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_versions_invalid_unknown_project
@@ -74,7 +74,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4990'
       X-RateLimit-Reset:
-      - '1576682771'
+      - '2147483647'
       X-XSS-Protection:
       - 1; mode=block
       content-length:

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_versions_no_token
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_versions_no_token
@@ -37,7 +37,7 @@ interactions:
       x-github-request-id: ['BF56:23A8:3340315:62F7CF2:5B7FEF90']
       x-ratelimit-limit: ['0']
       x-ratelimit-remaining: ['0']
-      x-ratelimit-reset: ['1535114656']
+      x-ratelimit-reset: ['2147483647']
       x-runtime-rack: ['0.011707']
       x-xss-protection: [1; mode=block]
     status: {code: 401, message: Unauthorized}

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_versions_no_version_retrieved
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_versions_no_version_retrieved
@@ -44,7 +44,7 @@ interactions:
       x-oauth-scopes: ['repo:status']
       x-ratelimit-limit: ['5000']
       x-ratelimit-remaining: ['5000']
-      x-ratelimit-reset: ['1537438156']
+      x-ratelimit-reset: ['2147483647']
       x-runtime-rack: ['0.107819']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_versions_releases_only
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_versions_releases_only
@@ -93,7 +93,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4999'
       X-RateLimit-Reset:
-      - '1571040888'
+      - '2147483647'
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_versions_unauthorized
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_versions_unauthorized
@@ -37,7 +37,7 @@ interactions:
       x-github-request-id: ['C4A8:23A5:15B7BE2:314B0A8:5B7FEF90']
       x-ratelimit-limit: ['0']
       x-ratelimit-remaining: ['0']
-      x-ratelimit-reset: ['1535114656']
+      x-ratelimit-reset: ['2147483647']
       x-runtime-rack: ['0.011671']
       x-xss-protection: [1; mode=block]
     status: {code: 401, message: Unauthorized}

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_versions_valid_with_version_url
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_versions_valid_with_version_url
@@ -71,7 +71,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4999'
       X-RateLimit-Reset:
-      - '1576682084'
+      - '2147483647'
       X-XSS-Protection:
       - 1; mode=block
       content-length:

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_versions_valid_without_version_url
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_get_versions_valid_without_version_url
@@ -73,7 +73,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4989'
       X-RateLimit-Reset:
-      - '1576682771'
+      - '2147483647'
       X-XSS-Protection:
       - 1; mode=block
       content-length:

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_plexus_utils
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_github.GithubBackendtests.test_plexus_utils
@@ -65,7 +65,7 @@ interactions:
       x-oauth-scopes: ['repo:status']
       x-ratelimit-limit: ['5000']
       x-ratelimit-remaining: ['4989']
-      x-ratelimit-reset: ['1534853506']
+      x-ratelimit-reset: ['2147483647']
       x-runtime-rack: ['0.082740']
       x-xss-protection: [1; mode=block]
     status: {code: 200, message: OK}


### PR DESCRIPTION
Just removing the ratelimit threshold will cause Anitya to fail on KeyError as instead of 403 when the ratelimit is reached GitHub returns 200 and json with error structure, which is completely different then standard response. To fix this we need to check the response header for specific parameters regarding rate limit.

This change is checking X-RateLimit-Remaining and X-RateLimit-Reset parameters in response header and raising RateLimitException when the limit is reached.