### PR TITLE
Use python 3.13 for mypy tests

### DIFF
--- a/mypy.cfg
+++ b/mypy.cfg
@@ -1,7 +1,7 @@
 # Global options:
 
 [mypy]
-python_version = 3.8
+python_version = 3.13
 warn_return_any = True
 warn_unused_configs = True
 ignore_missing_imports = True


### PR DESCRIPTION
The tests are currently failing as mypy is using python 3.8 and the latest pytest 9.0.0 is using features from python 3.10+. This will fix the issue.