### PR TITLE
Dark mode: eliminate flicker

### DIFF
--- a/anitya/app.py
+++ b/anitya/app.py
@@ -131,6 +131,9 @@ def inject_variable():
         cron_status=cron_status,
         user=current_user,
         available_backends=anitya_config["AUTHLIB_ENABLED_BACKENDS"],
+        bulb_on="""<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-lightbulb-fill" viewBox="0 0 16 16">
+                        <path d="M2 6a6 6 0 1 1 10.174 4.31c-.203.196-.359.4-.453.619l-.762 1.769A.5.5 0 0 1 10.5 13h-5a.5.5 0 0 1-.46-.302l-.761-1.77a2 2 0 0 0-.453-.618A5.98 5.98 0 0 1 2 6m3 8.5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1l-.224.447a1 1 0 0 1-.894.553H6.618a1 1 0 0 1-.894-.553L5.5 15a.5.5 0 0 1-.5-.5"/>
+                  </svg>""",  # noqa: E501
     )
 
 

--- a/anitya/templates/master.html
+++ b/anitya/templates/master.html
@@ -23,9 +23,7 @@
     <script type="text/javascript">
       const html = document.documentElement;
 
-      const bulbOn = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-lightbulb-fill" viewBox="0 0 16 16">
-                        <path d="M2 6a6 6 0 1 1 10.174 4.31c-.203.196-.359.4-.453.619l-.762 1.769A.5.5 0 0 1 10.5 13h-5a.5.5 0 0 1-.46-.302l-.761-1.77a2 2 0 0 0-.453-.618A5.98 5.98 0 0 1 2 6m3 8.5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1l-.224.447a1 1 0 0 1-.894.553H6.618a1 1 0 0 1-.894-.553L5.5 15a.5.5 0 0 1-.5-.5"/>
-                      </svg>`;
+      const bulbOn = `{{ bulb_on |safe }}`;
 
       const bulbOff =  `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-lightbulb-off" viewBox="0 0 16 16">
                           <path fill-rule="evenodd" d="M2.23 4.35A6 6 0 0 0 2 6c0 1.691.7 3.22 1.826 4.31.203.196.359.4.453.619l.762 1.769A.5.5 0 0 0 5.5 13a.5.5 0 0 0 0 1 .5.5 0 0 0 0 1l.224.447a1 1 0 0 0 .894.553h2.764a1 1 0 0 0 .894-.553L10.5 15a.5.5 0 0 0 0-1 .5.5 0 0 0 0-1 .5.5 0 0 0 .288-.091L9.878 12H5.83l-.632-1.467a3 3 0 0 0-.676-.941 4.98 4.98 0 0 1-1.455-4.405zm1.588-2.653.708.707a5 5 0 0 1 7.07 7.07l.707.707a6 6 0 0 0-8.484-8.484zm-2.172-.051a.5.5 0 0 1 .708 0l12 12a.5.5 0 0 1-.708.708l-12-12a.5.5 0 0 1 0-.708"/>
@@ -226,7 +224,9 @@
                 Rate ({{ cron_status.ratelimit_count }})
                 {% endif %}
 
-                <span id="theme-toggle"></span>
+                <span id="theme-toggle">
+                  {{ bulb_on | safe}}
+                </span>
             </p>
         </div>
     </footer>


### PR DESCRIPTION
addendum to #1962 to implement #1937

the `data-bs-theme` attribute is now set on `<html>`  during `<head>` parsing-- thereby eliminating the flashbang.

tested both with light and dark themes using Firefox 145 and Chrome 144.0.7534.0.

~**note**: the light bulb icon is wired up after `DOMContentLoaded` fires, which causes a minor pop-in for the icon. any suggestions for avoiding that are welcome.~ edit: addressed layout shift by sending initial `<svg>` from the server