### PR TITLE
fix(backends): correctly report error when package missing on PyPI

### DIFF
--- a/anitya/lib/backends/pypi.py
+++ b/anitya/lib/backends/pypi.py
@@ -45,6 +45,10 @@ class PypiBackend(BaseBackend):
         except Exception as err:  # pragma: no cover
             raise AnityaPluginException(f"Could not contact {url}") from err
 
+        # Handle missing packages explicitly
+        if req.status_code == 404:
+            raise AnityaPluginException(f"Package not found on PyPI: {url}")
+
         # Not modified
         if req.status_code == 304:
             return None
@@ -93,6 +97,10 @@ class PypiBackend(BaseBackend):
             req = cls.call_url(url, last_change=last_change)
         except Exception as err:  # pragma: no cover
             raise AnityaPluginException(f"Could not contact {url}") from err
+
+        # Handle missing packages explicitly
+        if req.status_code == 404:
+            raise AnityaPluginException(f"Package not found on PyPI: {url}")
 
         # Not modified
         if req.status_code == 304:

--- a/anitya/tests/lib/backends/test_pypi.py
+++ b/anitya/tests/lib/backends/test_pypi.py
@@ -184,3 +184,33 @@ class PypiBackendtests(DatabaseTestCase):
                 "0.3",
             ),
         )
+
+    def test_get_version_404(self):
+        """Test that a 404 response raises AnityaPluginException in get_version."""
+        project = models.Project(
+            name="non_existent_package",
+            homepage="https://pypi.org/project/non_existent_package/",
+            backend=BACKEND,
+        )
+
+        with mock.patch("anitya.lib.backends.BaseBackend.call_url") as m_call:
+            m_call.return_value = mock.Mock(status_code=404)
+            with self.assertRaisesRegex(
+                AnityaPluginException, "Package not found on PyPI"
+            ):
+                backend.PypiBackend.get_version(project)
+
+    def test_get_versions_404(self):
+        """Test that a 404 response raises AnityaPluginException in get_versions."""
+        project = models.Project(
+            name="non_existent_package",
+            homepage="https://pypi.org/project/non_existent_package/",
+            backend=BACKEND,
+        )
+
+        with mock.patch("anitya.lib.backends.BaseBackend.call_url") as m_call:
+            m_call.return_value = mock.Mock(status_code=404)
+            with self.assertRaisesRegex(
+                AnityaPluginException, "Package not found on PyPI"
+            ):
+                backend.PypiBackend.get_versions(project)

--- a/news/2001.bug
+++ b/news/2001.bug
@@ -1,0 +1,1 @@
+PyPI backend returns 404 but it's not reported as error


### PR DESCRIPTION
Proposed Change Currently, the PyPI backend logic does not distinguish between a 404 Not Found (missing package) and other errors. This PR updates get_version and get_versions to explicitly check for response.status_code == 404.

    Implementation Details

        Added a check for status code 404 immediately after the API call.

        Raises AnityaPluginException with a clear message ("Package not found on PyPI") if triggered.

    Verification Verified locally by creating a test script that attempts to fetch a non-existent package. Confirmed that the AnityaPluginException is now raised specifically for the 404 case.

    Fixes #2001