### PR TITLE
feat: add latest_version_created_on to api/v2/versions

### DIFF
--- a/anitya/api_v2.py
+++ b/anitya/api_v2.py
@@ -564,6 +564,7 @@ class VersionsResource(MethodView):
 
             {
                 "latest_version": "2.12",
+                "latest_version_created_on": "2026-03-31T14:30:00Z",
                 "versions": [
                     "2.12",
                     "2.11",
@@ -603,6 +604,15 @@ class VersionsResource(MethodView):
             "versions": project.versions,
             "stable_versions": [str(v) for v in project.stable_versions],
         }
+
+        latest_version_object = project.latest_version_object
+        if latest_version_object:
+            response.update(
+                {
+                    "latest_version_created_on": latest_version_object.created_on.isoformat()
+                }
+            )
+
         return response
 
     @authentication.require_token

--- a/anitya/tests/test_flask_api_v2.py
+++ b/anitya/tests/test_flask_api_v2.py
@@ -26,6 +26,7 @@ Tests for the Flask MethodView based v2 API
 from __future__ import unicode_literals
 
 import json
+import datetime
 from unittest import mock
 
 import anitya_schema
@@ -1376,10 +1377,16 @@ class VersionsResourceGetTests(DatabaseTestCase):
         self.session.add(project)
         self.session.commit()
 
-        version = models.ProjectVersion(project=project, version="1.0.0")
+        created_on = datetime.datetime.now()
+
+        version = models.ProjectVersion(
+            project=project, version="1.0.0", created_on=created_on
+        )
         self.session.add(version)
 
-        version = models.ProjectVersion(project=project, version="0.9.9")
+        version = models.ProjectVersion(
+            project=project, version="0.9.9", created_on=created_on
+        )
         self.session.add(version)
         self.session.commit()
 
@@ -1389,6 +1396,7 @@ class VersionsResourceGetTests(DatabaseTestCase):
 
         exp = {
             "latest_version": "1.0.0",
+            "latest_version_created_on": created_on.isoformat(),
             "versions": ["1.0.0", "0.9.9"],
             "stable_versions": ["1.0.0", "0.9.9"],
         }
@@ -1410,10 +1418,16 @@ class VersionsResourceGetTests(DatabaseTestCase):
         self.session.add(project)
         self.session.commit()
 
-        version = models.ProjectVersion(project=project, version="test-1.0.0")
+        created_on = datetime.datetime.now()
+
+        version = models.ProjectVersion(
+            project=project, version="test-1.0.0", created_on=created_on
+        )
         self.session.add(version)
 
-        version = models.ProjectVersion(project=project, version="test-0.9.9")
+        version = models.ProjectVersion(
+            project=project, version="test-0.9.9", created_on=created_on
+        )
         self.session.add(version)
         self.session.commit()
 
@@ -1423,6 +1437,7 @@ class VersionsResourceGetTests(DatabaseTestCase):
 
         exp = {
             "latest_version": "1.0.0",
+            "latest_version_created_on": created_on.isoformat(),
             "versions": ["1.0.0", "0.9.9"],
             "stable_versions": ["1.0.0", "0.9.9"],
         }

--- a/news/PR2023.feature
+++ b/news/PR2023.feature
@@ -1,0 +1,1 @@
+add latest_version_created_on to the API call api/v2/versions so that the scraped date of the latest version can be retrieved by using the API.


### PR DESCRIPTION
add latest_version_created_on to the API call api/v2/versions so that the scraped date of the latest version can be retrieved by using the API.