### PR TITLE
Fix Fedora Messaging Links

### DIFF
--- a/docs/admin-guide.rst
+++ b/docs/admin-guide.rst
@@ -41,7 +41,7 @@ with inline documentation is below.
 Anitya uses second configuration file for Fedora messaging. A sample
 configuration file is bellow. To know more about the configuration of
 fedora messaging please refer to
-`fedora messaging configuration documentation <https://fedora-messaging.readthedocs.io/en/latest/configuration.html>`_.
+`fedora messaging configuration documentation <https://fedora-messaging.readthedocs.io/en/latest/user-guide/configuration.html>`_.
 
 .. include:: ../files/config.toml.sample
    :literal:

--- a/docs/integrating-with-anitya.rst
+++ b/docs/integrating-with-anitya.rst
@@ -29,7 +29,7 @@ Via pip ::
   pip install fedora-messaging
 
 For how to start a local broker for `fedora messaging`. See
-`Fedora messaging documentation <https://fedora-messaging.readthedocs.io/en/latest/quick-start.html#local-broker>`_.
+`Fedora messaging documentation <https://fedora-messaging.readthedocs.io/en/latest/user-guide/quick-start.html#using-a-local-broker>`_.
 
 List of fedora messaging topics
 -------------------------------

--- a/files/config.toml.sample
+++ b/files/config.toml.sample
@@ -1,6 +1,6 @@
 # A sample configuration for fedora-messaging. This file is in the TOML format.
 # For complete details on all configuration options, see the documentation.
-# https://fedora-messaging.readthedocs.io/en/latest/configuration.html
+# https://fedora-messaging.readthedocs.io/en/latest/user-guide/configuration.html
 
 amqp_url = "amqp://"
 

--- a/news/PR2024.bug
+++ b/news/PR2024.bug
@@ -1,0 +1,1 @@
+Fix Fedora Messaging Documentation Links


### PR DESCRIPTION
Fixes broken links to https://fedora-messaging.readthedocs.io.