### PR TITLE
Fix missing escapes in tooltip help

### DIFF
--- a/anitya/templates/project_new.html
+++ b/anitya/templates/project_new.html
@@ -178,7 +178,7 @@
     $("#version_filter").tooltip();
     $("#regex").prop('title', "Python regex to use for version retrieval. " +
         "Matched groups will be concatenated by '.'. " +
-        "For example regex '(\d)_(\d)_(\d)' applied to '1_2_3' " +
+        "For example regex '(\\d)_(\\d)_(\\d)' applied to '1_2_3' " +
         "will convert version to '1.2.3'.");
     $("#regex").tooltip();
     $("#releases_only").prop('title', "Check releases instead of tags " +

--- a/news/PR2034.bug
+++ b/news/PR2034.bug
@@ -1,0 +1,1 @@
+Add missing escapes for the Custom Regex field


### PR DESCRIPTION
With the custom backend, the hover text for the Regex field says (in part):
```
For example regex '(d)_(d)_(d)' applied to '1_2_3' will convert version to '1.2.3'.
```
This PR fixes escapes in the python code so they appear in the hover text.  If you prefer, a raw string could be used instead.