### PR TITLE
Fix build of Anitya

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,10 +87,14 @@ exclude = [
   "anitya/tests"
 ]
 include = [
-  "LICENSE", "README.rst",
-  "createdb.py", "alembic.ini",
-  "files/anitya.toml.sample", "files/config.toml.sample",
-  "anitya/static/docs/**/*", "anitya/static/node_modules/**/*"
+  { path = "LICENSE", format = ["sdist", "wheel"] },
+  { path = "README.rst", format = ["sdist", "wheel"] },
+  { path = "createdb.py", format = ["sdist", "wheel"] },
+  { path = "alembic.ini", format = ["sdist", "wheel"] },
+  { path = "files/anitya.toml.sample", format = ["sdist", "wheel"] },
+  { path = "files/config.toml.sample", format = ["sdist", "wheel"] },
+  { path = "anitya/static/docs/**/*", format = ["sdist", "wheel"] },
+  { path = "anitya/static/node_modules/**/*", format = ["sdist", "wheel"] }
 ]
 
 [tool.poetry.scripts]


### PR DESCRIPTION
The build of Anitya was missing include files in wheel file, which caused issues when building it in OpenShift deployment. This commit is fixing that problem.