### PR TITLE
Fix for error on user management page

### DIFF
--- a/anitya/admin.py
+++ b/anitya/admin.py
@@ -552,8 +552,8 @@ def browse_users():
             users_query = users_query.limit(limit)
 
         users = db.session.scalars(users_query).all()
-        cnt_users = db.session.scalar(select(func.count())).select_from(
-            users_query.subquery()
+        cnt_users = db.session.scalar(
+            select(func.count()).select_from(users_query.subquery())
         )
     except Exception as err:
         _log.exception(err)

--- a/news/2047.bug
+++ b/news/2047.bug
@@ -1,0 +1,1 @@
+User management page throws 'int' object has no attribute 'select_from'


### PR DESCRIPTION
Wrongly used parenthesis caused error when opening the page and broke pagination on user management page.