### PR TITLE
Use ftpmirror.gnu.org for GNU backend

### DIFF
--- a/anitya/lib/backends/gnu.py
+++ b/anitya/lib/backends/gnu.py
@@ -24,7 +24,7 @@ class GnuBackend(BaseBackend):
     """
 
     name = "GNU project"
-    examples = ["https://ftp.gnu.org/pub/gnu/gnash/"]
+    examples = ["https://ftpmirror.gnu.org/pub/gnu/gnash/"]
 
     @classmethod
     def get_version_url(cls, project):
@@ -38,7 +38,7 @@ class GnuBackend(BaseBackend):
         Returns:
             str: url used for version checking
         """
-        url = f"https://ftp.gnu.org/gnu/{project.name}/"  # noqa: E231
+        url = f"https://ftpmirror.gnu.org/gnu/{project.name}/"  # noqa: E231
 
         return url
 

--- a/anitya/tests/lib/backends/test_gnu.py
+++ b/anitya/tests/lib/backends/test_gnu.py
@@ -98,7 +98,7 @@ class GnuBackendtests(DatabaseTestCase):
         project = models.Project(
             name="test", homepage="http://example.org", backend=BACKEND
         )
-        exp = "https://ftp.gnu.org/gnu/test/"
+        exp = "https://ftpmirror.gnu.org/gnu/test/"
 
         obs = backend.GnuBackend.get_version_url(project)
 
@@ -142,7 +142,7 @@ class GnuBackendtests(DatabaseTestCase):
         """Assert that not modified response is handled correctly"""
         pid = 1
         project = models.Project.get(self.session, pid)
-        exp_url = "https://ftp.gnu.org/gnu/gnash/"
+        exp_url = "https://ftpmirror.gnu.org/gnu/gnash/"
 
         with mock.patch("anitya.lib.backends.BaseBackend.call_url") as m_call:
             m_call.return_value = mock.Mock(status_code=304)

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_gnu.GnuBackendtests.test_custom_get_version
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_gnu.GnuBackendtests.test_custom_get_version
@@ -8,7 +8,7 @@ interactions:
       From: [admin@fedoraproject.org]
       User-Agent: [Anitya 0.11.0 at release-monitoring.org]
     method: GET
-    uri: https://ftp.gnu.org/gnu/gnash/
+    uri: https://ftpmirror.gnu.org/gnu/gnash/
   response:
     body:
       string: !!binary |
@@ -49,7 +49,7 @@ interactions:
       From: [admin@fedoraproject.org]
       User-Agent: [Anitya 0.11.0 at release-monitoring.org]
     method: GET
-    uri: https://ftp.gnu.org/gnu/fake/
+    uri: https://ftpmirror.gnu.org/gnu/fake/
   response:
     body: {string: !!python/unicode '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
 
@@ -65,7 +65,7 @@ interactions:
 
         <hr>
 
-        <address>Apache/2.4.7 (Trisquel_GNU/Linux) Server at ftp.gnu.org Port 443</address>
+        <address>Apache/2.4.7 (Trisquel_GNU/Linux) Server at ftpmirror.gnu.org Port 443</address>
 
         </body></html>
 
@@ -88,7 +88,7 @@ interactions:
       From: [admin@fedoraproject.org]
       User-Agent: [Anitya 0.11.0 at release-monitoring.org]
     method: GET
-    uri: https://ftp.gnu.org/gnu/subsurface/
+    uri: https://ftpmirror.gnu.org/gnu/subsurface/
   response:
     body: {string: !!python/unicode '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
 
@@ -104,7 +104,7 @@ interactions:
 
         <hr>
 
-        <address>Apache/2.4.7 (Trisquel_GNU/Linux) Server at ftp.gnu.org Port 443</address>
+        <address>Apache/2.4.7 (Trisquel_GNU/Linux) Server at ftpmirror.gnu.org Port 443</address>
 
         </body></html>
 

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_gnu.GnuBackendtests.test_custom_get_versions
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_gnu.GnuBackendtests.test_custom_get_versions
@@ -8,7 +8,7 @@ interactions:
       From: [admin@fedoraproject.org]
       User-Agent: [Anitya 0.11.0 at release-monitoring.org]
     method: GET
-    uri: https://ftp.gnu.org/gnu/gnash/
+    uri: https://ftpmirror.gnu.org/gnu/gnash/
   response:
     body:
       string: !!binary |
@@ -49,7 +49,7 @@ interactions:
       From: [admin@fedoraproject.org]
       User-Agent: [Anitya 0.11.0 at release-monitoring.org]
     method: GET
-    uri: https://ftp.gnu.org/gnu/fake/
+    uri: https://ftpmirror.gnu.org/gnu/fake/
   response:
     body: {string: !!python/unicode '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
 
@@ -65,7 +65,7 @@ interactions:
 
         <hr>
 
-        <address>Apache/2.4.7 (Trisquel_GNU/Linux) Server at ftp.gnu.org Port 443</address>
+        <address>Apache/2.4.7 (Trisquel_GNU/Linux) Server at ftpmirror.gnu.org Port 443</address>
 
         </body></html>
 
@@ -88,7 +88,7 @@ interactions:
       From: [admin@fedoraproject.org]
       User-Agent: [Anitya 0.11.0 at release-monitoring.org]
     method: GET
-    uri: https://ftp.gnu.org/gnu/subsurface/
+    uri: https://ftpmirror.gnu.org/gnu/subsurface/
   response:
     body: {string: !!python/unicode '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
 
@@ -104,7 +104,7 @@ interactions:
 
         <hr>
 
-        <address>Apache/2.4.7 (Trisquel_GNU/Linux) Server at ftp.gnu.org Port 443</address>
+        <address>Apache/2.4.7 (Trisquel_GNU/Linux) Server at ftpmirror.gnu.org Port 443</address>
 
         </body></html>
 

--- a/news/1935.bug
+++ b/news/1935.bug
@@ -1,0 +1,1 @@
+Use ftpmirror.gnu.org for GNU backend


### PR DESCRIPTION
Fixes #1935
  
Switches the GNU backend from `ftp.gnu.org` to `ftpmirror.gnu.org` for better reliability.

This picks up the work from #1938 (closed due to inactivity) – adds the missing test updates and news file