### PR TITLE
Fix for sort only working on the current page

### DIFF
--- a/anitya/db/models.py
+++ b/anitya/db/models.py
@@ -541,9 +541,9 @@ class Project(Base):
             return None
 
     @classmethod
-    def all(cls, session, page=None, count=False):
+    def all(cls, session, page=None, count=False, sort=None):
         """all"""
-        query = session.query(Project).order_by(sa.func.lower(Project.name))
+        query = _apply_sort(session.query(Project), sort)
 
         query = _paginate_query(query, page)
 
@@ -635,7 +635,7 @@ class Project(Base):
             return query.all()
 
     @classmethod
-    def search(cls, session, pattern, distro=None, page=None, count=False):
+    def search(cls, session, pattern, distro=None, page=None, count=False, sort=None):
         """Search the projects by their name or package name"""
 
         query1 = session.query(cls)
@@ -665,7 +665,8 @@ class Project(Base):
                 sa.func.lower(Packages.distro_name) == sa.func.lower(distro)
             )
 
-        query = query1.distinct().union(query2.distinct()).order_by(cls.name)
+        query = query1.distinct().union(query2.distinct())
+        query = _apply_sort(query, sort)
 
         query = _paginate_query(query, page)
 
@@ -676,9 +677,7 @@ class Project(Base):
 
     @classmethod
     def sort_projects(cls, projects, sort):
-        """
-        Sorts a list of projects objects based on a sort parameter.
-        """
+        """Sorts a list of project objects based on a sort parameter."""
         sort_attr, _, sort_order = sort.partition("_")
 
         attr_map = {"name": "name", "homepage": "homepage", "backend": "backend"}
@@ -691,6 +690,29 @@ class Project(Base):
         )
 
         return projects
+
+
+_SORT_ATTRS = {
+    "name": Project.name,
+    "homepage": Project.homepage,
+    "backend": Project.backend,
+}
+
+
+def _apply_sort(query, sort):
+    # Apply the sort before paginating so the order is global, not per page.
+    if not sort:
+        return query.order_by(sa.func.lower(Project.name))
+
+    sort_attr, _, sort_order = sort.partition("_")
+    column = _SORT_ATTRS.get(sort_attr)
+    if column is None:
+        return query.order_by(sa.func.lower(Project.name))
+
+    direction = sa.func.lower(column)
+    if sort_order == "desc":
+        return query.order_by(direction.desc().nulls_last())
+    return query.order_by(direction.asc().nulls_first())
 
 
 class ProjectVersion(Base):

--- a/anitya/templates/projects.html
+++ b/anitya/templates/projects.html
@@ -20,7 +20,7 @@
     <ul class="pagination pagination-sm">
       {% if page > 1%}
       <li class="page-item">
-        <a class="page-link" href="{{ page_url }}?page={{page - 1}}">
+        <a class="page-link" href="{{ page_url }}?page={{page - 1}}{% if sort %}&sort={{ sort }}{% endif %}">
           «
         </a>
       {% else %}
@@ -33,7 +33,7 @@
       </li>
       {% if page < total_page %}
       <li class="page-item">
-        <a class="page-link" href="{{ page_url }}?page={{page + 1}}">
+        <a class="page-link" href="{{ page_url }}?page={{page + 1}}{% if sort %}&sort={{ sort }}{% endif %}">
             »
         </a>
       {% else %}
@@ -115,7 +115,7 @@
       </li>
       {% if page < total_page %}
       <li class="page-item">
-        <a class="page-link" href="{{ page_url }}?page={{page + 1}}">
+        <a class="page-link" href="{{ page_url }}?page={{page + 1}}{% if sort %}&sort={{ sort }}{% endif %}">
             »
         </a>
       {% else %}

--- a/anitya/templates/search.html
+++ b/anitya/templates/search.html
@@ -16,10 +16,10 @@
       <li class="page-item">
         {% if distroname %}
         <a class="page-link" href="{{ url_for('anitya_ui.distro_projects_search',
-                    distroname=distroname, pattern=pattern, page=page-1 ) }}">
+                    distroname=distroname, pattern=pattern, page=page-1, sort=sort ) }}">
         {% else %}
         <a class="page-link" href="{{ url_for('anitya_ui.projects_search',
-                  pattern=pattern, page=page-1 ) }}">
+                  pattern=pattern, page=page-1, sort=sort ) }}">
         {% endif %}
             «
         </a>
@@ -35,10 +35,10 @@
       <li class="page-item">
         {% if distroname %}
         <a class="page-link" href="{{ url_for('anitya_ui.distro_projects_search',
-              distroname=distroname, pattern=pattern, page=page+1 ) }}">
+              distroname=distroname, pattern=pattern, page=page+1, sort=sort ) }}">
         {% else %}
         <a class="page-link" href="{{ url_for('anitya_ui.projects_search',
-                  pattern=pattern, page=page+1 ) }}">
+                  pattern=pattern, page=page+1, sort=sort ) }}">
         {% endif %}
           »
         </a>

--- a/anitya/tests/test_flask.py
+++ b/anitya/tests/test_flask.py
@@ -551,6 +551,49 @@ class FlaskTest(DatabaseTestCase):
         self.assertEqual(output.status_code, 200)
         self.assertEqual(output.data.count(b'<a href="/project/'), 3)
 
+    def test_projects_sort_applies_across_pages(self):
+        """The sort order must hold across pagination, not just within a page."""
+        create_distro(self.session)
+        for i in range(60):
+            self.session.add(
+                models.Project(
+                    name=f"project-{i:02d}",
+                    homepage=f"https://example.com/project-{i:02d}",
+                    backend="custom",
+                    ecosystem_name="pypi",
+                )
+            )
+        self.session.commit()
+
+        page1 = self.app.get("/projects/?page=1&sort=name_desc")
+        page2 = self.app.get("/projects/?page=2&sort=name_desc")
+        self.assertEqual(page1.status_code, 200)
+        self.assertEqual(page2.status_code, 200)
+
+        names1 = self._project_names(page1.data)
+        names2 = self._project_names(page2.data)
+
+        self.assertEqual(len(names1), 50)
+        self.assertEqual(len(names2), 10)
+        self.assertEqual(set(names1) & set(names2), set())
+        # In desc order, page 1's last name must come after page 2's first.
+        self.assertGreater(names1[-1], names2[0])
+
+    def test_projects_invalid_sort_falls_back(self):
+        """An unknown sort key should fall back to the default ordering."""
+        create_distro(self.session)
+        create_project(self.session)
+
+        output = self.app.get("/projects/?sort=garbage_asc")
+        self.assertEqual(output.status_code, 200)
+        self.assertEqual(output.data.count(b'<a href="/project/'), 3)
+
+    @staticmethod
+    def _project_names(html):
+        import re
+
+        return re.findall(rb'/project/\d+/">([^<]+)', html)
+
     def test_distros(self):
         """Test the distros function."""
         create_distro(self.session)

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -176,11 +176,8 @@ def projects():
     except ValueError:
         page = 1
 
-    projects = models.Project.all(db.session, page=page)
+    projects = models.Project.all(db.session, page=page, sort=sort)
     projects_count = models.Project.all(db.session, count=True)
-
-    if sort:
-        projects = models.Project.sort_projects(projects, sort)
 
     total_page = int(ceil(projects_count / float(50)))
 
@@ -191,6 +188,7 @@ def projects():
         total_page=total_page,
         projects_count=projects_count,
         page=page,
+        sort=sort,
     )
 
 
@@ -379,28 +377,31 @@ def projects_search(pattern=None):
     except ValueError:
         page = 1
 
-    projects = models.Project.search(db.session, pattern=pattern, page=page)
+    projects = models.Project.search(db.session, pattern=pattern, page=page, sort=sort)
 
     if str(exact).lower() not in ["1", "true"]:
         # Extends the search
         for proj in models.Project.search(
-            db.session, pattern=get_extended_pattern(pattern), page=page
+            db.session, pattern=get_extended_pattern(pattern), page=page, sort=sort
         ):
             if proj not in projects:
                 projects.append(proj)
         projects_count = models.Project.search(
             db.session, pattern=get_extended_pattern(pattern), count=True
         )
+        # Two paginated SQL queries are merged here, so SQL-side ordering
+        # no longer holds across the union; sort the combined list instead.
+        projects = models.Project.sort_projects(projects, sort)
     else:
-        projects_count = models.Project.search(db.session, pattern=pattern, count=True)
+        projects_count = models.Project.search(
+            db.session, pattern=pattern, count=True, sort=sort
+        )
 
     if projects_count == 1 and projects[0].name == pattern.replace("*", ""):
         flask.flash("Only one result matching with an exact match, redirecting")
         return flask.redirect(
             flask.url_for("anitya_ui.project", project_id=projects[0].id)
         )
-
-    projects = models.Project.sort_projects(projects, sort)
 
     total_page = int(ceil(projects_count / float(50)))
 

--- a/news/1778.bug
+++ b/news/1778.bug
@@ -1,0 +1,2 @@
+Sort by name, homepage, and backend on the projects and search pages now
+applies to the entire dataset instead of only the current page.


### PR DESCRIPTION
Fixes #1778

The sort was happening in Python after the DB paginated, so each page sorted itself. Pushed the sort into the SQL query so it runs against the whole dataset before pagination.

Also fixed the pagination links dropping the `sort` param.