### PR TITLE
Fold _apply_sort into Project.sort_projects

### DIFF
--- a/anitya/db/models.py
+++ b/anitya/db/models.py
@@ -543,7 +543,7 @@ class Project(Base):
     @classmethod
     def all(cls, session, page=None, count=False, sort=None):
         """all"""
-        query = _apply_sort(session.query(Project), sort)
+        query = cls.sort_projects(session.query(Project), sort)
 
         query = _paginate_query(query, page)
 
@@ -666,7 +666,7 @@ class Project(Base):
             )
 
         query = query1.distinct().union(query2.distinct())
-        query = _apply_sort(query, sort)
+        query = cls.sort_projects(query, sort)
 
         query = _paginate_query(query, page)
 
@@ -676,43 +676,29 @@ class Project(Base):
             return query.all()
 
     @classmethod
-    def sort_projects(cls, projects, sort):
-        """Sorts a list of project objects based on a sort parameter."""
+    def sort_projects(cls, items, sort):
+        """Sort a query or list of projects by the given sort spec."""
+        if isinstance(items, sa.orm.Query):
+            if not sort:
+                return items.order_by(sa.func.lower(Project.name))
+            sort_attr, _, sort_order = sort.partition("_")
+            attr_map = {"name": "name", "homepage": "homepage", "backend": "backend"}
+            column = getattr(Project, attr_map.get(sort_attr, "name"))
+            direction = sa.func.lower(column)
+            if sort_order == "desc":
+                return items.order_by(direction.desc().nulls_last())
+            return items.order_by(direction.asc().nulls_first())
+
+        if not sort:
+            sort = "name_asc"
         sort_attr, _, sort_order = sort.partition("_")
-
         attr_map = {"name": "name", "homepage": "homepage", "backend": "backend"}
-
         sort_by = attr_map.get(sort_attr, "name")
-
-        projects.sort(
+        items.sort(
             key=lambda project: getattr(project, sort_by, "").lower(),
             reverse=sort_order == "desc",
         )
-
-        return projects
-
-
-_SORT_ATTRS = {
-    "name": Project.name,
-    "homepage": Project.homepage,
-    "backend": Project.backend,
-}
-
-
-def _apply_sort(query, sort):
-    # Apply the sort before paginating so the order is global, not per page.
-    if not sort:
-        return query.order_by(sa.func.lower(Project.name))
-
-    sort_attr, _, sort_order = sort.partition("_")
-    column = _SORT_ATTRS.get(sort_attr)
-    if column is None:
-        return query.order_by(sa.func.lower(Project.name))
-
-    direction = sa.func.lower(column)
-    if sort_order == "desc":
-        return query.order_by(direction.desc().nulls_last())
-    return query.order_by(direction.asc().nulls_first())
+        return items
 
 
 class ProjectVersion(Base):

--- a/anitya/tests/test_project.py
+++ b/anitya/tests/test_project.py
@@ -119,6 +119,12 @@ class Projecttests(DatabaseTestCase):
         self.assertEqual(projects[0].name, "geany")
         self.assertEqual(projects[0].homepage, "https://www.geany.org/")
 
+    def test_sort_projects_list_default(self):
+        """sort_projects on a list with no sort spec falls back to name asc."""
+        create_project(self.session)
+        projects = models.Project.sort_projects(models.Project.all(self.session), None)
+        self.assertEqual([p.name for p in projects], ["geany", "R2spec", "subsurface"])
+
     def test_distro_repr(self):
         """Test the __repr__ function of Project."""
         create_project(self.session)

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -389,8 +389,6 @@ def projects_search(pattern=None):
         projects_count = models.Project.search(
             db.session, pattern=get_extended_pattern(pattern), count=True
         )
-        # Two paginated SQL queries are merged here, so SQL-side ordering
-        # no longer holds across the union; sort the combined list instead.
         projects = models.Project.sort_projects(projects, sort)
     else:
         projects_count = models.Project.search(


### PR DESCRIPTION
## Summary
Follow-up to #2054.

Updated `Project.sort_projects` to handle both SQL queries and Python lists, removed `_apply_sort` and `_SORT_ATTRS`, and routed `Project.all` and `Project.search` through it.

I kept the final `Project.sort_projects(projects, sort)` call in the extended-search merge. Removing it breaks the ordering because the results of two independently sorted `Project.search` calls are merged in Python.

### Note
If you'd prefer a different approach for the merge, I'm happy to follow up with another implementation.