### PR TITLE
Add pre-creation project version validation

### DIFF
--- a/anitya/api_v2.py
+++ b/anitya/api_v2.py
@@ -19,7 +19,11 @@ from webargs.flaskparser import FlaskParser
 from anitya import authentication
 from anitya.db import db, models, paginate
 from anitya.lib import plugins, utilities
-from anitya.lib.exceptions import AnityaException, ProjectExists
+from anitya.lib.exceptions import (
+    AnityaException,
+    InvalidProjectException,
+    ProjectExists,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -526,6 +530,7 @@ class ProjectsResource(MethodView):
                 version_filter=args["version_filter"],
                 regex=args["regex"],
                 insecure=args["insecure"],
+                validate=True,
             )
             db.session.commit()
             if args["check_release"]:
@@ -534,6 +539,8 @@ class ProjectsResource(MethodView):
                 except AnityaException as err:
                     _log.error(str(err))
             return project.__json__(), 201
+        except InvalidProjectException as err:
+            return jsonify({"error": str(err)}), 400
         except ProjectExists as e:
             response = jsonify(e.to_dict())
             response.status_code = 409

--- a/anitya/lib/exceptions.py
+++ b/anitya/lib/exceptions.py
@@ -59,6 +59,20 @@ class ProjectExists(AnityaException):
         return "Unable to create project since it already exists."
 
 
+class InvalidProjectException(AnityaException):
+    """Raised when a project fails the pre-creation version check."""
+
+    def __init__(self, message=None):
+        self.message = message or (
+            "The check failed: no versions could be retrieved for this project. "
+            "Please verify the project configuration (backend, homepage, "
+            "version URL, etc.) and try again."
+        )
+
+    def __str__(self):
+        return self.message
+
+
 class AnityaInvalidMappingException(AnityaException):
     """Specific exception class for invalid mapping."""
 

--- a/anitya/lib/utilities.py
+++ b/anitya/lib/utilities.py
@@ -148,6 +148,7 @@ def check_project_release(project, session, test=False):
         project.logs = "No new version found"
 
     if test:
+        session.close()
         return upstream_versions[::-1]
 
     if upstream_versions:

--- a/anitya/lib/utilities.py
+++ b/anitya/lib/utilities.py
@@ -148,7 +148,6 @@ def check_project_release(project, session, test=False):
         project.logs = "No new version found"
 
     if test:
-        session.close()
         return upstream_versions[::-1]
 
     if upstream_versions:
@@ -205,8 +204,25 @@ def create_project(
     insecure=False,
     releases_only=False,
     dry_run=False,
+    validate=False,
 ):
     """Create the project in the database."""
+    if validate:
+        _validate_backend(
+            name=name,
+            homepage=homepage,
+            backend=backend,
+            version_scheme=version_scheme,
+            version_pattern=version_pattern,
+            version_url=version_url,
+            version_prefix=version_prefix,
+            pre_release_filter=pre_release_filter,
+            version_filter=version_filter,
+            regex=regex,
+            insecure=insecure,
+            releases_only=releases_only,
+        )
+
     project = models.Project(
         name=name,
         homepage=homepage,
@@ -242,6 +258,56 @@ def create_project(
         )
         session.commit()
     return project
+
+
+def _validate_backend(
+    name,
+    homepage,
+    backend="custom",
+    version_scheme="RPM",
+    version_pattern=None,
+    version_url=None,
+    version_prefix=None,
+    pre_release_filter=None,
+    version_filter=None,
+    regex=None,
+    insecure=False,
+    releases_only=False,
+):
+    """Check that the backend can retrieve versions using an in-memory project."""
+    backend_plugin = plugins.get_plugin(backend)
+    if not backend_plugin:
+        raise exceptions.AnityaException(f'No backend was found for "{backend}"')
+
+    temp_project = models.Project(
+        name=name,
+        homepage=homepage,
+        backend=backend,
+        version_scheme=version_scheme,
+        version_pattern=version_pattern,
+        version_url=version_url,
+        regex=regex,
+        version_prefix=version_prefix,
+        pre_release_filter=pre_release_filter,
+        version_filter=version_filter,
+        insecure=insecure,
+        releases_only=releases_only,
+    )
+
+    try:
+        backend_plugin.get_versions(temp_project)
+    except exceptions.AnityaException as err:
+        _log.info(
+            "Pre-creation check failed for project '%s' (%s): %s",
+            name,
+            backend,
+            str(err),
+        )
+        raise exceptions.InvalidProjectException(
+            f"The check failed: could not retrieve versions. "
+            f"Error: {err}. Please verify the project configuration "
+            f"(backend, homepage, version URL, etc.) and try again."
+        ) from err
 
 
 def edit_project(

--- a/anitya/tests/lib/test_utilities.py
+++ b/anitya/tests/lib/test_utilities.py
@@ -1007,3 +1007,103 @@ class RemoveSuffixTests(unittest.TestCase):
             utilities.remove_suffix(url, "/tags"),
             "https://github.com/libexpat/libexpat",
         )
+
+
+class CreateProjectValidationTests(DatabaseTestCase):
+    """Tests for create_project with validate=True."""
+
+    @mock.patch(
+        "anitya.lib.backends.npmjs.NpmjsBackend.get_versions",
+        return_value=["1.0.0", "0.9.9"],
+    )
+    def test_create_project_validate_success(self, mock_method):
+        """Test that a valid project is created when validation passes."""
+        with fml_testing.mock_sends(anitya_schema.ProjectCreated):
+            project = utilities.create_project(
+                self.session,
+                name="test_project",
+                homepage="https://example.com/test",
+                backend="npmjs",
+                user_id="noreply@fedoraproject.org",
+                validate=True,
+            )
+        mock_method.assert_called_once()
+        self.assertEqual(project.name, "test_project")
+        project_objs = models.Project.all(self.session)
+        self.assertEqual(len(project_objs), 1)
+
+    @mock.patch(
+        "anitya.lib.backends.npmjs.NpmjsBackend.get_versions",
+        mock.Mock(
+            side_effect=exceptions.AnityaPluginException("Could not contact npmjs")
+        ),
+    )
+    def test_create_project_validate_failure(self):
+        """Test that InvalidProjectException is raised and nothing is saved."""
+        with self.assertRaises(exceptions.InvalidProjectException) as ctx:
+            utilities.create_project(
+                self.session,
+                name="bad_project",
+                homepage="https://example.com/nonexistent",
+                backend="npmjs",
+                user_id="noreply@fedoraproject.org",
+                validate=True,
+            )
+        self.assertIn("could not retrieve versions", str(ctx.exception))
+        self.assertIn("Could not contact npmjs", str(ctx.exception))
+
+        # Nothing saved
+        project_objs = models.Project.all(self.session)
+        self.assertEqual(len(project_objs), 0)
+
+    @mock.patch(
+        "anitya.lib.backends.npmjs.NpmjsBackend.get_versions",
+        mock.Mock(side_effect=exceptions.RateLimitException("2099-01-01T00:00:00Z")),
+    )
+    def test_create_project_validate_rate_limit(self):
+        """Test that rate limiting during validation raises InvalidProjectException."""
+        with self.assertRaises(exceptions.InvalidProjectException):
+            utilities.create_project(
+                self.session,
+                name="rate_limited_project",
+                homepage="https://example.com/ratelimit",
+                backend="npmjs",
+                user_id="noreply@fedoraproject.org",
+                validate=True,
+            )
+
+        # Nothing saved
+        project_objs = models.Project.all(self.session)
+        self.assertEqual(len(project_objs), 0)
+
+    @mock.patch(
+        "anitya.lib.backends.npmjs.NpmjsBackend.get_versions",
+        return_value=["1.0.0"],
+    )
+    def test_create_project_without_validate(self, mock_method):
+        """Test that validate=False (default) skips the check."""
+        with fml_testing.mock_sends(anitya_schema.ProjectCreated):
+            utilities.create_project(
+                self.session,
+                name="no_validate",
+                homepage="https://example.com/skip",
+                backend="npmjs",
+                user_id="noreply@fedoraproject.org",
+            )
+        # get_versions should NOT be called when validate is not set
+        mock_method.assert_not_called()
+
+    def test_create_project_validate_invalid_backend(self):
+        """Test that validation fails for a missing backend."""
+        with self.assertRaises(exceptions.AnityaException) as ctx:
+            utilities.create_project(
+                self.session,
+                name="bad_backend",
+                homepage="https://example.com/bad",
+                backend="nonexistent_backend",
+                user_id="noreply@fedoraproject.org",
+                validate=True,
+            )
+        self.assertIn(
+            'No backend was found for "nonexistent_backend"', str(ctx.exception)
+        )

--- a/anitya/tests/test_flask.py
+++ b/anitya/tests/test_flask.py
@@ -320,8 +320,34 @@ class NewProjectTests(DatabaseTestCase):
                     b'<td><label for="regex">Regex</label></td>' in output.data
                 )
 
+    @mock.patch("anitya.lib.utilities._validate_backend")
+    def test_new_project_invalid_validation(self, mock_validate):
+        """Assert a project that fails validation results in an HTTP 400."""
+        mock_validate.side_effect = exceptions.InvalidProjectException(
+            "Check failed: validation"
+        )
+        with login_user(self.flask_app, self.user):
+            with self.flask_app.test_client() as c:
+                output = c.get("/project/new", follow_redirects=True)
+                self.assertEqual(output.status_code, 200)
+                csrf_token = output.data.split(
+                    b'name="csrf_token" type="hidden" value="'
+                )[1].split(b'">')[0]
+                data = {
+                    "name": "fedocal",
+                    "homepage": "https://example.com/fedocal",
+                    "backend": "PyPI",
+                    "version_scheme": "RPM",
+                    "csrf_token": csrf_token,
+                }
+                output = c.post("/project/new", data=data, follow_redirects=True)
+                self.assertEqual(output.status_code, 400)
+                self.assertTrue(b"<h1>Add project</h1>" in output.data)
+                self.assertTrue(b"Check failed: validation" in output.data)
+
+    @mock.patch("anitya.lib.utilities._validate_backend")
     @mock.patch("anitya.lib.utilities.check_project_release")
-    def test_new_project_with_check_release(self, patched):
+    def test_new_project_with_check_release(self, patched_check, patched_validate):
         """test_new_project_with_check_release"""
         output = self.app.get("/project/new", follow_redirects=True)
         with login_user(self.flask_app, self.user):
@@ -345,7 +371,7 @@ class NewProjectTests(DatabaseTestCase):
                     b'<li class="list-group-item list-group-item-default">'
                     b"Project created</li>" in output.data
                 )
-                patched.assert_not_called()
+                patched_check.assert_not_called()
 
                 # check_release_on
                 data["name"] += "xxx"
@@ -357,7 +383,7 @@ class NewProjectTests(DatabaseTestCase):
                     b'<li class="list-group-item list-group-item-default">'
                     b"Project created</li>" in output.data
                 )
-                patched.assert_called_once_with(mock.ANY, mock.ANY)
+                patched_check.assert_called_once_with(mock.ANY, mock.ANY)
 
     @mock.patch("anitya.lib.utilities.check_project_release")
     def test_new_project_with_mapping_check_release_error(self, patched):

--- a/anitya/tests/test_flask_api_v2.py
+++ b/anitya/tests/test_flask_api_v2.py
@@ -1257,6 +1257,24 @@ class ProjectsResourcePostTests(DatabaseTestCase):
         self.assertEqual("http://python-requests.org", data["homepage"])
         self.assertEqual("requests", data["name"])
 
+    @mock.patch("anitya.lib.utilities._validate_backend")
+    def test_invalid_project_validation(self, mock_validate):
+        """Test that invalid project validation results in 400 bad request."""
+        mock_validate.side_effect = exceptions.InvalidProjectException("Check failed")
+        request_data = {
+            "backend": "PyPI",
+            "homepage": "http://python-requests.org",
+            "name": "invalid-req",
+        }
+
+        output = self.app.post(
+            "/api/v2/projects/", headers=self.auth, data=request_data
+        )
+
+        data = _read_json(output)
+        self.assertEqual(output.status_code, 400)
+        self.assertEqual("Check failed", data["error"])
+
     def test_valid_request_json(self):
         """
         Assert that request with header specifying json will be handled as well.

--- a/anitya/ui.py
+++ b/anitya/ui.py
@@ -542,6 +542,7 @@ def new_project():
                 regex=form.regex.data.strip() if form.regex.data else None,
                 user_id=flask.g.user.username,
                 releases_only=form.releases_only.data,
+                validate=True,
             )
             db.session.commit()
 
@@ -557,6 +558,18 @@ def new_project():
                 db.session.commit()
 
             flask.flash("Project created")
+        except exceptions.InvalidProjectException as err:
+            flask.flash(str(err), "errors")
+            return (
+                flask.render_template(
+                    "project_new.html",
+                    context="Add",
+                    current="Add projects",
+                    form=form,
+                    plugins=backend_plugins,
+                ),
+                400,
+            )
         except exceptions.AnityaException as err:
             flask.flash(str(err))
             return (

--- a/news/1940.feature
+++ b/news/1940.feature
@@ -1,4 +1,1 @@
-New projects now require a successful version check before being added.
-Projects whose backend cannot retrieve any versions are rejected with a
-descriptive error message, preventing broken entries from consuming
-resources in the periodic check service.
+Add pre-creation project version validation.

--- a/news/1940.feature
+++ b/news/1940.feature
@@ -1,0 +1,4 @@
+New projects now require a successful version check before being added.
+Projects whose backend cannot retrieve any versions are rejected with a
+descriptive error message, preventing broken entries from consuming
+resources in the periodic check service.


### PR DESCRIPTION
Fixes #1940
                          
This adds a validation step when adding a new project to prevent broken configurations from being saved to the database.                                          
                                                         
Previously, projects were saved first, and if they were broken (e.g., bad URL or backend couldn't find versions), they would sit in the database and waste resources during the periodic check service.           
  
Now, we perform a dry-run test using the backend plugin *before* saving. If no versions can be found, the project is rejected immediately with a helpful error message.

Assisted-By: Claude Opus 4.6