### PR TITLE
Fix transparent navbar on scroll

### DIFF
--- a/anitya/templates/master.html
+++ b/anitya/templates/master.html
@@ -61,7 +61,7 @@
   >
     <header>
       <!-- Static navbar -->
-      <nav class="navbar navbar-expand-lg fixed-top">
+      <nav class="navbar navbar-expand-lg fixed-top bg-body-tertiary">
         <div id="wrap" class="container-fluid ms-2">
             <a class="navbar-brand" href="{{url_for('anitya_ui.index')}}">
                 release-monitoring.org

--- a/news/2061.bug
+++ b/news/2061.bug
@@ -1,0 +1,1 @@
+Fix transparent navbar on scroll


### PR DESCRIPTION
## Summary
Fixes a UI bug where the page content was visible *through* the top navigation bar when scrolling down.  
                                                         
When dark mode was added previously, the old solid background class was removed from the navbar but wasn't replaced. This PR simply adds `bg-body-tertiary` back to the navbar so it has a solid background that correctly adapts to both light and dark mode.

**Before**
<img width="600" alt="image" src="https://github.com/user-attachments/assets/db7b8a6a-9c65-4f69-9b99-92aea7975384" />

**After**
<img width="600" alt="image" src="https://github.com/user-attachments/assets/b686db9d-2fbc-4a58-90ca-7d01eba97895" />
