### PR TITLE
Apply version filters to historically stored versions

### DIFF
--- a/anitya/db/models.py
+++ b/anitya/db/models.py
@@ -404,8 +404,41 @@ class Project(Base):
         backend = BACKEND_PLUGINS.get_plugin(self.backend)
         return backend.get_version_url(self)
 
-    def get_sorted_version_objects(self):
+    def is_version_filtered(self, version):
+        """
+        Check if a given version string matches the project's version filter.
+
+        This checks both the raw version string and the version string with the prefix
+        applied, if the project has a version_prefix configured.
+
+        Args:
+            version (str): The version string to check.
+
+        Returns:
+            bool: True if the version is filtered, False otherwise.
+        """
+        if not self.version_filter:
+            return False
+
+        filter_list = self.version_filter.split(";")
+        prefixed_version = (
+            f"{self.version_prefix}{version}" if self.version_prefix else version
+        )
+
+        for filter_str in filter_list:
+            filter_str = filter_str.strip()
+            if not filter_str:
+                continue
+            if filter_str in version or filter_str in prefixed_version:
+                return True
+
+        return False
+
+    def get_sorted_version_objects(self, ignore_filter=False):
         """Return list of all version objects stored, sorted from newest to oldest.
+
+        Args:
+           ignore_filter (bool, optional): If True, do not apply version filters. Defaults to False.
 
         Returns:
            :obj:`list` of :obj:`anitya.lib.versions.Base`: List of version objects
@@ -421,6 +454,7 @@ class Project(Base):
                 commit_url=v_obj.commit_url,
             )
             for v_obj in self.versions_obj
+            if ignore_filter or not self.is_version_filtered(v_obj.version)
         ]
         sorted_versions = list(reversed(sorted(versions)))
         return sorted_versions

--- a/anitya/templates/project.html
+++ b/anitya/templates/project.html
@@ -44,7 +44,9 @@
                 <div class="list-group-item-text">
                   {% if project.versions %}
                     {% if project.latest_version_object and project.latest_version_object.commit_url %}
-                      <div property="doap:release" typeof="doap:Version">{{ project.latest_version }} (<a href="{{ project.latest_version_object.commit_url }}">commit</a>)</div>
+                      <div property="doap:release" typeof="doap:Version">{{ project.latest_version_object.version }} (<a href="{{ project.latest_version_object.commit_url }}">commit</a>)</div>
+                    {% elif project.latest_version_object %}
+                      <div property="doap:release" typeof="doap:Version">{{ project.latest_version_object.version }}</div>
                     {% else %}
                       <div property="doap:release" typeof="doap:Version">{{ project.latest_version }}</div>
                     {% endif %}
@@ -265,9 +267,20 @@
               <th>Delete</th>
               {% endif %}
             </tr>
-            {% for version in project.get_sorted_version_objects() %}
-            <tr property="doap:release" typeof="doap:Version" class="align-middle">
-              <td property="doap:revision">{{ version.parse() }}</td>
+            {% for version in project.get_sorted_version_objects(ignore_filter=is_admin) %}
+            {% set is_hidden = is_admin and project.is_version_filtered(version.version) %}
+            <tr property="doap:release" typeof="doap:Version" class="align-middle{% if is_hidden %} text-muted opacity-75{% endif %}">
+              <td property="doap:revision" class="align-middle">
+                <span class="me-2">{{ version.parse() }}</span>
+                {% if is_hidden %}
+                <span class="badge bg-secondary fw-normal" title="This version is filtered from public view">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" class="bi bi-eye-slash-fill me-1" viewBox="0 0 16 16" style="margin-top:-2px;">
+                    <path d="m10.79 12.912-1.614-1.615a3.5 3.5 0 0 1-4.474-4.474l-2.06-2.06C.938 6.278 0 8 0 8s3 5.5 8 5.5a7 7 0 0 0 2.79-.588M5.21 3.088A7 7 0 0 1 8 2.5c5 0 8 5.5 8 5.5s-.939 1.721-2.641 3.238l-2.062-2.062a3.5 3.5 0 0 0-4.474-4.474z"/>
+                    <path d="M5.525 7.646a2.5 2.5 0 0 0 2.829 2.829zm4.95.708-2.829-2.83a2.5 2.5 0 0 1 2.829 2.829zm3.171 6-12-12 .708-.708 12 12z"/>
+                  </svg>Filtered
+                </span>
+                {% endif %}
+              </td>
               {% if version.created_on %}
               <td>{{ version.created_on.strftime('%Y-%m-%d %H:%M') }}</td>
               {% else %}

--- a/anitya/tests/db/test_models.py
+++ b/anitya/tests/db/test_models.py
@@ -192,6 +192,64 @@ class ProjectTests(DatabaseTestCase):
 
         self.assertEqual([str(version) for version in version_objects], ["1.0.0"])
 
+    def test_is_version_filtered(self):
+        """Test is_version_filtered logic."""
+        project = models.Project(
+            name="test",
+            homepage="https://example.com",
+            ecosystem_name="pypi",
+            version_filter="alpha;beta",
+            version_prefix="v",
+        )
+        self.session.add(project)
+        self.session.commit()
+
+        # Unfiltered versions
+        self.assertFalse(project.is_version_filtered("1.0.0"))
+
+        # Filtered directly
+        self.assertTrue(project.is_version_filtered("1.0.0-alpha"))
+        self.assertTrue(project.is_version_filtered("beta-2.0"))
+
+        # Filtered by prefix logic. E.g. filter 'v1.0', version '1.0.0', prefix 'v'
+        project.version_filter = "v1.0"
+        self.assertTrue(project.is_version_filtered("1.0.0"))
+        self.assertFalse(project.is_version_filtered("2.0.0"))
+
+        # Test empty filter segments (covers the `continue` branch)
+        project.version_filter = "alpha;;"
+        self.assertFalse(project.is_version_filtered("1.0.0"))
+        self.assertTrue(project.is_version_filtered("1.0.0-alpha"))
+
+    def test_get_sorted_version_objects_filtered(self):
+        """Test that get_sorted_version_objects applies the version filter."""
+        project = models.Project(
+            name="test",
+            homepage="https://example.com",
+            ecosystem_name="pypi",
+            version_scheme="Semantic",
+            version_filter="alpha;beta",
+        )
+        self.session.add(project)
+        self.session.commit()
+
+        v1 = models.ProjectVersion(project_id=project.id, version="1.0.0")
+        v2 = models.ProjectVersion(project_id=project.id, version="1.0.0-alpha")
+        self.session.add(v1)
+        self.session.add(v2)
+        self.session.commit()
+
+        # Regular user view (filtered)
+        version_objects = project.get_sorted_version_objects()
+        self.assertEqual([str(v) for v in version_objects], ["1.0.0"])
+
+        # Admin view (unfiltered)
+        version_objects_admin = project.get_sorted_version_objects(ignore_filter=True)
+        # Assuming semantic sorting puts 1.0.0-alpha before or after 1.0.0
+        self.assertEqual(len(version_objects_admin), 2)
+        self.assertIn("1.0.0", [str(v) for v in version_objects_admin])
+        self.assertIn("1.0.0-alpha", [str(v) for v in version_objects_admin])
+
     def test_get_last_created_version(self):
         """
         Assert that last retrieved version is returned.

--- a/news/2062.bug
+++ b/news/2062.bug
@@ -1,0 +1,1 @@
+Apply version filters to already-stored versions when the filter is updated.


### PR DESCRIPTION
### Summary 
Fixes #2062
Fixes #1816

This PR applies the `version_filter` logic directly inside `get_sorted_version_objects`, so older, already fetched versions are retroactively hidden from public view when they match an active filter.

### Changes

- Added `.strip()` to filter values. Accidental spaces in filters such as `2021; 2022` no longer break filtering.
- Filtered versions remain visible in the admin table, but are visually dimmed and marked with a "Filtered" badge to make their inactive status clear.
- The "Latest version" shown at the top of the page now updates to the newest unfiltered version.

https://github.com/user-attachments/assets/eac89e9e-e112-489f-bd16-1023b9de5e19
