### PR TITLE
Fix duplicate /gnu/ path in GNU backend version check

### DIFF
--- a/anitya/lib/backends/gnu.py
+++ b/anitya/lib/backends/gnu.py
@@ -24,7 +24,7 @@ class GnuBackend(BaseBackend):
     """
 
     name = "GNU project"
-    examples = ["https://ftpmirror.gnu.org/pub/gnu/gnash/"]
+    examples = ["https://ftpmirror.gnu.org/gnash/"]
 
     @classmethod
     def get_version_url(cls, project):
@@ -38,7 +38,7 @@ class GnuBackend(BaseBackend):
         Returns:
             str: url used for version checking
         """
-        url = f"https://ftpmirror.gnu.org/gnu/{project.name}/"  # noqa: E231
+        url = f"https://ftpmirror.gnu.org/{project.name}/"  # noqa: E231
 
         return url
 

--- a/anitya/tests/lib/backends/test_gnu.py
+++ b/anitya/tests/lib/backends/test_gnu.py
@@ -98,7 +98,7 @@ class GnuBackendtests(DatabaseTestCase):
         project = models.Project(
             name="test", homepage="http://example.org", backend=BACKEND
         )
-        exp = "https://ftpmirror.gnu.org/gnu/test/"
+        exp = "https://ftpmirror.gnu.org/test/"
 
         obs = backend.GnuBackend.get_version_url(project)
 
@@ -142,7 +142,7 @@ class GnuBackendtests(DatabaseTestCase):
         """Assert that not modified response is handled correctly"""
         pid = 1
         project = models.Project.get(self.session, pid)
-        exp_url = "https://ftpmirror.gnu.org/gnu/gnash/"
+        exp_url = "https://ftpmirror.gnu.org/gnash/"
 
         with mock.patch("anitya.lib.backends.BaseBackend.call_url") as m_call:
             m_call.return_value = mock.Mock(status_code=304)

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_gnu.GnuBackendtests.test_custom_get_version
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_gnu.GnuBackendtests.test_custom_get_version
@@ -8,7 +8,7 @@ interactions:
       From: [admin@fedoraproject.org]
       User-Agent: [Anitya 0.11.0 at release-monitoring.org]
     method: GET
-    uri: https://ftpmirror.gnu.org/gnu/gnash/
+    uri: https://ftpmirror.gnu.org/gnash/
   response:
     body:
       string: !!binary |
@@ -49,7 +49,7 @@ interactions:
       From: [admin@fedoraproject.org]
       User-Agent: [Anitya 0.11.0 at release-monitoring.org]
     method: GET
-    uri: https://ftpmirror.gnu.org/gnu/fake/
+    uri: https://ftpmirror.gnu.org/fake/
   response:
     body: {string: !!python/unicode '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
 
@@ -88,7 +88,7 @@ interactions:
       From: [admin@fedoraproject.org]
       User-Agent: [Anitya 0.11.0 at release-monitoring.org]
     method: GET
-    uri: https://ftpmirror.gnu.org/gnu/subsurface/
+    uri: https://ftpmirror.gnu.org/subsurface/
   response:
     body: {string: !!python/unicode '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
 

--- a/anitya/tests/request-data/anitya.tests.lib.backends.test_gnu.GnuBackendtests.test_custom_get_versions
+++ b/anitya/tests/request-data/anitya.tests.lib.backends.test_gnu.GnuBackendtests.test_custom_get_versions
@@ -8,7 +8,7 @@ interactions:
       From: [admin@fedoraproject.org]
       User-Agent: [Anitya 0.11.0 at release-monitoring.org]
     method: GET
-    uri: https://ftpmirror.gnu.org/gnu/gnash/
+    uri: https://ftpmirror.gnu.org/gnash/
   response:
     body:
       string: !!binary |
@@ -49,7 +49,7 @@ interactions:
       From: [admin@fedoraproject.org]
       User-Agent: [Anitya 0.11.0 at release-monitoring.org]
     method: GET
-    uri: https://ftpmirror.gnu.org/gnu/fake/
+    uri: https://ftpmirror.gnu.org/fake/
   response:
     body: {string: !!python/unicode '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
 
@@ -88,7 +88,7 @@ interactions:
       From: [admin@fedoraproject.org]
       User-Agent: [Anitya 0.11.0 at release-monitoring.org]
     method: GET
-    uri: https://ftpmirror.gnu.org/gnu/subsurface/
+    uri: https://ftpmirror.gnu.org/subsurface/
   response:
     body: {string: !!python/unicode '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
 

--- a/news/2073.bug
+++ b/news/2073.bug
@@ -1,0 +1,1 @@
+Fix GNU backend URL on ftpmirror.gnu.org


### PR DESCRIPTION
### Summary
 
Fixes #2073

The switch to `ftpmirror.gnu.org` in #1935 / #2053 retained the `/gnu/` path segment. Since the mirror redirector already routes directly to the mirrors' GNU root, this caused a duplicated path (e.g., `/gnu//gnu/libtool/`) and resulted in 404s for all GNU projects.

This removes the redundant `/gnu/` path from the backend URL and updates the associated test cassettes.